### PR TITLE
Add filesystem reset protection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Adds app owned WNFS
 - Separates initialize into app and permissionedApp entrypoints
 - Make email optional at registration
+- Add reset option to bootstrapFileSystem
 
 ### v0.32.0
 

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -124,7 +124,7 @@ export const bootstrapFileSystem = async (
       const logCid = await cidLog.newest() // data root in browser
 
       if (dataCid !== null || logCid !== undefined) {
-        throw new Error("Bootstrap operation will reset an existing filesystem. Please set reset to true if this behavior is desired.")
+        throw new Error("Bootstrap operation will \"reset\" an existing filesystem. Please set reset to true if this behavior is desired.")
       }
     }
 

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -3,6 +3,7 @@ import { CID } from "multiformats/cid"
 import FileSystem from "./fs/index.js"
 
 import * as cidLog from "./common/cid-log.js"
+import * as common from "./common/index.js"
 import * as crypto from "./crypto/index.js"
 import * as debug from "./common/debug.js"
 import * as dataRoot from "./data-root.js"
@@ -105,11 +106,32 @@ export async function loadFileSystem(
 /**
  * Create a new filesystem and assign it to a user.
  *
- * Warning: This function will override a user's filesystem with an empty one.
- *
  * @param permissions The permissions to initialize the filesystem
+ * @param options Optional params
+ * @param options.reset Override an existing filesystem with an empty one
  */
-export const bootstrapFileSystem = async (permissions: Permissions): Promise<FileSystem> => {
+export const bootstrapFileSystem = async (
+  permissions: Permissions,
+  options: { reset?: boolean } = { reset: false }
+): Promise<FileSystem> => {
+  const { reset } = options
+  const authedUsername = await common.authenticatedUsername()
+
+  // Check for authed user and existing filesystem
+  if (authedUsername) {
+    if (!reset) {
+      const dataCid = navigator.onLine ? await dataRoot.lookup(authedUsername) : null // data root on server or DNS
+      const logCid = await cidLog.newest() // data root in browser
+
+      if (dataCid !== null || logCid !== undefined) {
+        throw new Error("Bootstrap operation will reset an existing filesystem. Please set reset to true if this behavior is desired.")
+      }
+    }
+
+  } else {
+    throw new Error("Cannot bootstrap filesystem because an authed user could not be found.")
+  }
+
   // Get or create root read key
   const rootKey = await readKey()
 
@@ -179,18 +201,21 @@ const ROOT_PERMISSIONS = { fs: { private: [pathing.root()], public: [pathing.roo
 /**
  * Load a user's root file system.
  */
- export const loadRootFileSystem = async (): Promise<FileSystem> => {
+export const loadRootFileSystem = async (): Promise<FileSystem> => {
   return await loadFileSystem(ROOT_PERMISSIONS)
 }
 
 /**
  * Create a new filesystem with public and private roots and assign it to a user.
  *
- * Warning: This function will override a user's filesystem with an empty one.
+ * @param options Optional params
+ * @param options.reset Override an existing filesystem with an empty one
  */
- export const bootstrapRootFileSystem = async (): Promise<FileSystem> => {
-  return await bootstrapFileSystem(ROOT_PERMISSIONS)
- }
+export const bootstrapRootFileSystem = async (
+  options: { reset?: boolean } = { reset: false }
+): Promise<FileSystem> => {
+  return await bootstrapFileSystem(ROOT_PERMISSIONS, options)
+}
 
 
 


### PR DESCRIPTION
## Summary

This PR implements the following **features**

* [x] Adds a `reset` option to `bootstrapFileSystem`
* [x] Adds a check for authed user in `bootstrapFileSystem`

The existing `boostrapFileSystem` function will override a user's filesystem with an empty one. This function is dangerous and could use some guard rails.

When the `reset` option is set to `false`, we check if a filesystem exists and throw an exception if so. The `reset` option can be explicitly set to `true` if a filesystem reset is desired. The `reset` option defaults to `false`.

The check for an authed user was needed for checking the filesystem, but is a general improvement because we need a user here.

## Test plan (required)

The change can be tested by calling `bootstrapFileSystem` in an app where a user already has a filesystem. The call should fail, but setting the `reset` option to `true` should succeed and reset the filesystem.

## Closing issues

Closes #396 

## After Merge
* [ ] Does this change invalidate any docs or tutorials? No docs for this one yet
* [ ] Does this change require a release to be made? Yes, I'll release an alpha with it

