### PR TITLE
Improve peer list storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fixes the depedency-injected `lookupDnsLink` function
 - Fixes issue with IPFS peer-list storage
+- Removes Vite warning caused by a dynamic import
 
 
 ### v0.34.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 #### Bug fixes
 
-Fixes the depedency-injected `lookupDnsLink` function
+- Fixes the depedency-injected `lookupDnsLink` function
+- Fixes issue with IPFS peer-list storage
 
 
 ### v0.34.0
@@ -22,6 +23,7 @@ Enable new EXPERIMENTAL public file system version 3.0.0 using rs-wnfs. Use this
 - No longer uses a locally-shared IPFS client (was originally using a shared worker). This fixes various error messages you may have seen relating to CIDs.
 
 
+
 ### v0.32.0
 
 #### Features
@@ -37,13 +39,16 @@ Fixes issue with loading private shares.
 Updated ipfs-related dependencies.
 
 
+
 ### v0.31.1
 
 Move `madge` and `typedoc-plugin-missing-exports` from `dependencies` into `devDependencies`.
 
+
 ### v0.31.0
 
 Fixes circular dependencies.
+
 
 
 ### v0.30.0

--- a/src/ipfs/config.ts
+++ b/src/ipfs/config.ts
@@ -44,8 +44,7 @@ export const nodeWithPkg = (pkg: IPFSPackage): Promise<IPFS> => {
  */
 export const pkgFromCDN = async (cdn_url: string): Promise<IPFSPackage> => {
   if (!cdn_url) throw new Error("This function requires a URL to a CDN")
-  /* @vite-ignore */
-  return import(/* webpackIgnore: true */ cdn_url).then(_ => (self as any).IpfsCore as IPFSPackage)
+  return import(/* @vite-ignore *//* webpackIgnore: true */ cdn_url).then(_ => (self as any).IpfsCore as IPFSPackage)
 }
 
 // /**

--- a/src/ipfs/node.ts
+++ b/src/ipfs/node.ts
@@ -149,11 +149,11 @@ export async function createAndConnect(pkg: IPFSPackage): Promise<IPFSCore> {
 // PEERS
 // -----
 
-const STORAGE_KEY = "ipfs_peers_1660901513"
+const STORAGE_KEY = "ipfs_peers_1661540056"
 
 
 export function fetchFissionPeers(): Promise<string[]> {
-  const peersUrl = `${setup.getApiEndpoint()}/ipfs/peers`
+  const peersUrl = `${setup.endpoints.api}/ipfs/peers`
 
   return fetch(peersUrl)
     .then(r => r.json())
@@ -167,11 +167,11 @@ export async function listPeers(): Promise<Multiaddr[]> {
   let peers
   const maybePeers = await localforage.getItem(STORAGE_KEY)
 
-  if (t.isString(maybePeers)) {
-    peers = maybePeers.split(",")
+  if (t.isString(maybePeers) && maybePeers.trim() !== "") {
+    peers = JSON.parse(maybePeers)
 
     fetchFissionPeers().then(list =>
-      localforage.setItem(STORAGE_KEY, list.join(","))
+      localforage.setItem(STORAGE_KEY, JSON.stringify(list))
     ).catch(err => {
       // don't throw
       console.error(err)
@@ -179,7 +179,7 @@ export async function listPeers(): Promise<Multiaddr[]> {
 
   } else {
     peers = await fetchFissionPeers()
-    await localforage.setItem(STORAGE_KEY, peers.join(","))
+    await localforage.setItem(STORAGE_KEY, JSON.stringify(peers))
 
   }
 


### PR DESCRIPTION
This fixes an issue with certain endpoint configurations and empty peer lists.

Sometimes it was using `/api/vx/ipfs/peers` instead of `/ipfs/peers`, and it didn't work with empty peer lists (or peer lists that didn't have usable peers in it).

Also fixes #416