### PR TITLE
Fix: Resolve exact wnfs version in unpkg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### v0.34.2
+
+- Fixes `LinkError: import object field '__wbg_putBlock_88cdb3be9020efb7' is not a Function` when loading WASM.
+
 ### v0.34.1
 
 #### Bug fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webnative",
-  "version": "0.34.1",
+  "version": "0.34.2",
   "description": "Fission Webnative SDK",
   "keywords": [
     "WebCrypto",
@@ -75,6 +75,7 @@
     "@types/throttle-debounce": "^2.1.0",
     "@typescript-eslint/eslint-plugin": "^5.10.0",
     "@typescript-eslint/parser": "^5.10.0",
+    "@yarnpkg/lockfile": "^1.1.0",
     "copyfiles": "^2.4.1",
     "esbuild": "^0.15.5",
     "eslint": "^8.7.0",
@@ -115,7 +116,7 @@
     "throttle-debounce": "^3.0.1",
     "tweetnacl": "^1.0.3",
     "uint8arrays": "^3.0.0",
-    "wnfs": "^0.1.7-alpha5"
+    "wnfs": "^0.1.7"
   },
   "tsd": {
     "directory": "lib"

--- a/scripts/gen-version.js
+++ b/scripts/gen-version.js
@@ -1,13 +1,34 @@
 import { promises as fs } from "fs"
+import lockfile from "@yarnpkg/lockfile"
 
-fs.readFile("package.json", { encoding: "utf-8" }).then(pkg => {
+fs.readFile("package.json", { encoding: "utf-8" }).then(async pkg => {
     const pkgJson = JSON.parse(pkg)
     const version = pkgJson.version
+    const wnfsVersionBound = pkgJson.dependencies.wnfs
+
+    if (wnfsVersionBound == null) {
+        throw new Error(`Expected 'wnfs' in dependencies, but not found`)
+    }
+
+    const lockFileContent = await fs.readFile("yarn.lock", { encoding: "utf8" })
+    const result = lockfile.parse(lockFileContent)
+
+    if (result.type !== "success") {
+        throw new Error(`Couldn't parse yarn.lock file (result type: ${result.type})`)
+    }
+
+    const lockFileJSON = result.object
+    const resolvedWasmWnfsVersion = lockFileJSON[`wnfs@${wnfsVersionBound}`].version
+
+    if (resolvedWasmWnfsVersion == null) {
+        throw new Error(`Couldn't find resolved wnfs version in yarn.lock file`)
+    }
+
     let versionModule = ""
     versionModule += `export const VERSION = ${JSON.stringify(version, null, 4)}\n`
-    versionModule += `export const WASM_WNFS_VERSION = ${JSON.stringify(pkgJson.dependencies.wnfs, null, 4)}\n`
-    return fs.writeFile("src/common/version.ts", versionModule, { encoding: "utf-8" })
+    versionModule += `export const WASM_WNFS_VERSION = ${JSON.stringify(resolvedWasmWnfsVersion, null, 4)}\n`
+    await fs.writeFile("src/common/version.ts", versionModule, { encoding: "utf-8" })
 }).catch(e => {
     console.error(`There was an issue while trying to generate a "src/common/version.ts" file: ${e.message}\n${e}`)
-    process.exit(1)
+    throw e
 })

--- a/src/common/version.ts
+++ b/src/common/version.ts
@@ -1,2 +1,2 @@
-export const VERSION = "0.34.1"
-export const WASM_WNFS_VERSION = "^0.1.7-alpha5"
+export const VERSION = "0.34.2"
+export const WASM_WNFS_VERSION = "0.1.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1480,6 +1480,11 @@
   resolved "https://registry.npmjs.org/@vascosantos/moving-average/-/moving-average-1.1.0.tgz"
   integrity sha512-MVEJ4vWAPNbrGLjz7ITnHYg+YXZ6ijAqtH5/cHwSoCpbvuJ98aLXwFfPKAUfZpJMQR5uXB58UJajbY130IRF/w==
 
+"@yarnpkg/lockfile@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+  integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
+
 abort-controller@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
@@ -6278,10 +6283,10 @@ which@2.0.2, which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
-wnfs@^0.1.7-alpha5:
-  version "0.1.7-alpha5"
-  resolved "https://registry.yarnpkg.com/wnfs/-/wnfs-0.1.7-alpha5.tgz#35a74edcf4895adec0806c20537a5bdcbb2ff9b2"
-  integrity sha512-wJ0SX06y/ogu1VU52Y2OvFpIR6bTgNso60w45aa3uWE5Mxf5wWnkjNgxT0VTGc9yX6ehBCUTZurKl6Mmx6BIHQ==
+wnfs@^0.1.7:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/wnfs/-/wnfs-0.1.7.tgz#e8f85fabafbb9bb85a92fc4c3ef3d12e6c4c4712"
+  integrity sha512-WTadILZSNX7Ti+jy1QgqGtWp0pLHvPAG+ERsNWge2DuR8P8x+U/CM9QjYqJb7wqBkbSoboZgeBspetybIzNQgw==
 
 word-wrap@^1.2.3, word-wrap@~1.2.3:
   version "1.2.3"


### PR DESCRIPTION
We were previously using urls like `https://unpkg.com/wnfs@^0.1.7-alpha5` to fetch the WASM blob.
This is very problematic, since that URL's contents can change when we publish new versions of the `wnfs` npm package.
And we need the `.wasm` file to match *exactly* the version of the JS glue code around it.

So publishing a newer version lead to unpkg redirecting the `0.1.7-alpha5` version to `0.1.7` and breaking:
![image](https://user-images.githubusercontent.com/1430958/187945867-5ccee982-c68d-4a91-98d4-df3a2007111e.png)

So, we need to ask unpkg for *exactly* the version we want.

I wrote some code that looks the exact version we resolved wnfs to in the yarn lockfile, and we're using that instead.