### PR TITLE
Refactor load filesystem

### DIFF
--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -33,8 +33,6 @@ import { setup } from "./setup/internal.js"
  * @param username Optional, username of the user to load the file system from.
  *                 Will try to load the file system of the authenticated user
  *                 by default. Throws an error if there's no authenticated user.
- * @param rootKey Optional, AES key to be the root key of a new filesystem.
- *                Will be used if a filesystem hasn't been created yet.
  */
 export async function loadFileSystem(
   permissions: Maybe<Permissions>,
@@ -190,6 +188,21 @@ const loadFromCid = async (cid: CID, permissions: Maybe<Permissions>): Promise<F
 
 // CREATE
 
+/**
+ * Create a filesystem
+ *
+ * @param permissions The permissions from initialise.
+ *                    Pass `null` if working without permissions
+ * @param rootKey AES key to be the root key of a new filesystem
+ * @returns
+ */
+export const createFileSystem = async (permissions: Maybe<Permissions>, rootKey: string) => {
+  const p = permissions || undefined
+  const fs = await FileSystem.empty({ permissions: p, rootKey })
+  await addSampleData(fs)
+
+  return fs
+}
 
 /**
  * Create a new filesystem and assign it to a user.

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -167,7 +167,7 @@ export class FileSystem {
   /**
    * Loads an existing file system from a CID.
    */
-  static async fromCID(cid: CID, opts: FileSystemOptions = {}): Promise<FileSystem | null> {
+  static async fromCID(cid: CID, opts: FileSystemOptions = {}): Promise<FileSystem> {
     const { permissions, localOnly } = opts
     const root = await RootTree.fromCID({ cid, permissions })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,23 +50,21 @@ export async function app(options: AppInitOptions): Promise<AppState> {
   const authedUsername = await common.authenticatedUsername()
 
   if (authedUsername && useWnfs) {
-    const dataCid = navigator.onLine ? await dataRoot.lookup(authedUsername) : null // data root on server or DNS
-    const logCid = await cidLog.newest() // data root in browser
-    const rootPermissions = { fs: { private: [pathing.root()], public: [pathing.root()] } }
-
-    if (dataCid === null && logCid === undefined) {
-      return appState.scenarioAuthed(
-        authedUsername,
-        await bootstrapFileSystem(rootPermissions)
-      )
-    } else {
+    try {
       const fs = options.loadFileSystem === false ?
         undefined :
-        await loadFileSystem(rootPermissions, authedUsername)
+        await loadRootFileSystem()
 
       return appState.scenarioAuthed(
         authedUsername,
         fs
+      )
+    } catch {
+
+      // Bootstrap filesystem if one doesn't exist
+      return appState.scenarioAuthed(
+        authedUsername,
+        await bootstrapRootFileSystem()
       )
     }
 


### PR DESCRIPTION
## Summary

This PR implements the following **features**

* [x] Adds data root polling to `loadFileSystem`
* [x] Removes filesystem creation from `loadFileSystem`
* [x] Adds `getLogCid` and `getDataRoot` for determining filesystem root CIDs (with optional polling in `getDataRoot`)
* [x] Adds `loadFromCid` to load a filesystem with a CID
* [x] Adds `createFileSystem`

The primary motivation for this PR is to improve the robustness of loading a filesystem from a data root. In #420, we observed that a data root may be missing when a user attempts to link a second device immediately after creating an account.

Loading a filesystem may occur offline or online. The steps for loading are

- Offline
  - Load from the latest log CID locally
  - If no log CID, poll for the data root for ten seconds with the hope of coming online 🤞
  - Otherwise, throw an exception 🧨
- Online
  - Determine the latest log CID and the data root (check the data root once, no polling)
  - If both could be determined, load the filesystem and fast forward them as needed
  - If no log CID, load from the data root
  - If neither, poll for the data root for ten seconds 🙏 
  - Otherwise, if all else fails, throw an exception 💥 

The goal is to load the filesystem with whatever is available as quickly as possible, but poll for the data root when necessary.

`createFileSystem` is added to cover cases where an empty filesystem should be created. It appears this is only needed when a root key is passed to `permissionedApp`.

## Test plan (required)

Testing in the [Webnative app template](https://github.com/fission-codes/webnative-app-template) covers cases where the filesystem is loaded from `webnative.app`.

Loading from the lobby should work with any permissioned app. Testing it over here has been with [React TodoMVC](https://github.com/fission-codes/react-todomvc).

## Closing issues

Closes #420

## After Merge
* [ ] Does this change invalidate any docs or tutorials? No
* [ ] Does this change require a release to be made? Yes, we can test it a bit before releasing it.
