### PR TITLE
Fix "Could not locate user DID in DNS" uncaught exceptions in device linking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,6 @@ The documentation should give you some information on how the various components
 - Removal of the `webnative.initialise`, `app` and `permissionedApp` functions. These have been replaced by the `program` function mentioned above.
 - Removal of the `fs.appPath` function, replaced with the `appData` function located in the path module.
 
-**Fixes**
-
-- Fixes `Could not locate user DID in DNS` uncaught exception reported after successfully linking a device
-
 ### v0.34.2
 
 - Fixes `LinkError: import object field '__wbg_putBlock_88cdb3be9020efb7' is not a Function` when loading WASM.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ The documentation should give you some information on how the various components
 - Removal of the `webnative.initialise`, `app` and `permissionedApp` functions. These have been replaced by the `program` function mentioned above.
 - Removal of the `fs.appPath` function, replaced with the `appData` function located in the path module.
 
+**Fixes**
+
+- Fixes `Could not locate user DID in DNS` uncaught exception reported after successfully linking a device
+
 ### v0.34.2
 
 - Fixes `LinkError: import object field '__wbg_putBlock_88cdb3be9020efb7' is not a Function` when loading WASM.

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "util": "^0.12.4"
       },
       "engines": {
-        "node": ">=15"
+        "node": ">=16"
       }
     },
     "node_modules/@achingbrain/ip-address": {


### PR DESCRIPTION
## Summary

This PR fixes/implements the following **bugs**

* [x] Fixes "Could not locate user DID in DNS" uncaught exceptions

Uncaught exceptions are reported in the console after device linking, but they are spurious because we retry a few times until we are successful. The change here removes the thrown exceptions until the last attempt.

## Test plan (required)

To test the change:

1. Clone [Webnative app template](https://github.com/webnative-examples/webnative-app-template/tree/icidasset/webnative-0.35) and update Webnative to use `bgins/fix-did-root-exceptions`
2. Register a new user
3. Link the user's account on a new device
4. No uncaught exceptions should be reported, but warnings may be displayed on failed attempts

## Closing issues

Fixes #430

## After Merge
* [ ] Does this change invalidate any docs or tutorials? It does not
* [ ] Does this change require a release to be made? To be released with the other `0.35.0` changes

