### PR TITLE
Fix `waitForRootDid` retry issues

### DIFF
--- a/src/components/auth/channel.ts
+++ b/src/components/auth/channel.ts
@@ -69,7 +69,6 @@ const waitForRootDid = async (
     const rootDidInterval = setInterval(async () => {
       console.warn("Could not fetch root DID. Retrying")
       rootDid = await reference.didRoot.lookup(username).catch(() => {
-        clearInterval(rootDidInterval)
         return null
       })
 

--- a/src/components/auth/channel.ts
+++ b/src/components/auth/channel.ts
@@ -63,12 +63,12 @@ const waitForRootDid = async (
   }
 
   return new Promise((resolve, reject) => {
-    const maxRetries = 3
+    const maxRetries = 10
     let tries = 0
 
     const rootDidInterval = setInterval(async () => {
-      console.warn("Could not fetch root DID. Retrying")
       rootDid = await reference.didRoot.lookup(username).catch(() => {
+        console.warn("Could not fetch root DID. Retrying.")
         return null
       })
 
@@ -81,7 +81,7 @@ const waitForRootDid = async (
 
       clearInterval(rootDidInterval)
       resolve(rootDid)
-    }, 2000)
+    }, 1000)
   })
 }
 


### PR DESCRIPTION
## Summary

* [x] Remove premature `clearInterval` in `waitForRootDid`
* [x] Increase number of retries and retry frequency in `waitForRootDid`

During device linking, we lookup the root DID for a username. We should retry the lookup a few times, but an early `clearInterval` was stopping retries after the second attempt.

This PR also increases the number of attempts and their frequency to make this lookup more robust.

## Test plan (required)

Go through the account linking flow with an existing user.

Go through it a second time with a non-existent user. The console should report ten warnings before throwing an exception and giving up.

## Closing issues

Closes #446 

## After Merge
* [ ] Does this change invalidate any docs or tutorials? It does not.
* [ ] Does this change require a release to be made? Should be released with the other `0.35.0` changes

