### PR TITLE
Add missing `waitForRootDid` changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### v0.35.1
+
+- Fixes `waitForRootDid` retry issues. The function only attempted twice and not frequently enough.
+
 ### v0.35.0
 
 Full rewrite of webnative. 🎉

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### v0.35.1
 
-- Fixes `waitForRootDid` retry issues. The function only attempted twice and not frequently enough.
+- Fixes `waitForRootDid` retry issues. The function did not make enough attempts nor did it make them frequently enough.
 
 ### v0.35.0
 


### PR DESCRIPTION
## Summary

This PR implements the following **features**

* Add `waitForRootDid` retry issues changelog entry

We pushed this fix into the `0.35.1` release so this PR adds a changelog entry for it.

