### PR TITLE
Add migration section to guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,3 +220,8 @@ file.history.prior(1606236743)
 
 
 [https://guide.fission.codes/developers/webnative/sharing-private-data](https://guide.fission.codes/developers/webnative/sharing-private-data)
+
+
+## Migration
+
+Some versions of Webnative require apps to migrate their codebase to address breaking changes. Please see our [migration guide](https://guide.fission.codes/developers/webnative/migration) for help migrating your apps to the latest Webnative version.


### PR DESCRIPTION
## Summary

This PR implements the following **features**

* [x] Add a migration section to the README

This provides general information about migrations and links to the migration section in the Fission guide.

## Closing issues

Closes #453 

## After Merge
* [x] Does this change invalidate any docs or tutorials? Nope.
* [x] Does this change require a release to be made? It does not.

