### PR TITLE
Add function overload signatures to path.appData()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### v0.35.2
+
+Fixes issue with the types of the `path.appData` function. Now has the correct overloads.
+
 ### v0.35.1
 
 - Fixes `waitForRootDid` retry issues. The function did not make enough attempts nor did it make them frequently enough.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webnative",
-  "version": "0.35.1",
+  "version": "0.35.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "webnative",
-      "version": "0.35.1",
+      "version": "0.35.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@ipld/dag-cbor": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webnative",
-  "version": "0.35.1",
+  "version": "0.35.2",
   "description": "Webnative SDK",
   "keywords": [
     "WebCrypto",

--- a/src/common/version.ts
+++ b/src/common/version.ts
@@ -1,2 +1,2 @@
-export const VERSION = "0.35.1"
+export const VERSION = "0.35.2"
 export const WASM_WNFS_VERSION = "0.1.7"

--- a/src/path/index.node.test.ts
+++ b/src/path/index.node.test.ts
@@ -1,6 +1,7 @@
 import expect from "expect"
 import * as fc from "fast-check"
-import * as pathing from "./index.js"
+import * as Path from "./index.js"
+import { DirectoryPath, FilePath } from "./index.js"
 
 
 describe("the path helpers", () => {
@@ -13,28 +14,28 @@ describe("the path helpers", () => {
   it("creates directory paths", () => {
     fc.assert(
       fc.property(fc.array(fc.hexaString()), data => {
-        expect(pathing.directory(...data)).toEqual({
+        expect(Path.directory(...data)).toEqual({
           directory: data
         })
       })
     )
 
     expect(() =>
-      pathing.directory("/")
+      Path.directory("/")
     ).toThrow()
   })
 
   it("creates file paths", () => {
     fc.assert(
       fc.property(fc.array(fc.hexaString()), data => {
-        expect(pathing.file(...data)).toEqual({
+        expect(Path.file(...data)).toEqual({
           file: data
         })
       })
     )
 
     expect(() =>
-      pathing.file("/")
+      Path.file("/")
     ).toThrow()
   })
 
@@ -45,31 +46,31 @@ describe("the path helpers", () => {
 
   it("creates a path from a POSIX formatted string", () => {
     expect(
-      pathing.fromPosix("foo/bar/")
+      Path.fromPosix("foo/bar/")
     ).toEqual(
       { directory: [ "foo", "bar" ] }
     )
 
     expect(
-      pathing.fromPosix("/foo/bar/")
+      Path.fromPosix("/foo/bar/")
     ).toEqual(
       { directory: [ "foo", "bar" ] }
     )
 
     expect(
-      pathing.fromPosix("/")
+      Path.fromPosix("/")
     ).toEqual(
       { directory: [] }
     )
 
     expect(
-      pathing.fromPosix("foo/bar")
+      Path.fromPosix("foo/bar")
     ).toEqual(
       { file: [ "foo", "bar" ] }
     )
 
     expect(
-      pathing.fromPosix("/foo/bar")
+      Path.fromPosix("/foo/bar")
     ).toEqual(
       { file: [ "foo", "bar" ] }
     )
@@ -78,19 +79,19 @@ describe("the path helpers", () => {
 
   it("converts a path to the POSIX format", () => {
     expect(
-      pathing.toPosix({ directory: [ "foo", "bar" ] })
+      Path.toPosix({ directory: [ "foo", "bar" ] })
     ).toEqual(
       "foo/bar/"
     )
 
     expect(
-      pathing.toPosix({ directory: [] })
+      Path.toPosix({ directory: [] })
     ).toEqual(
       ""
     )
 
     expect(
-      pathing.toPosix({ file: [ "foo", "bar" ] })
+      Path.toPosix({ file: [ "foo", "bar" ] })
     ).toEqual(
       "foo/bar"
     )
@@ -101,21 +102,55 @@ describe("the path helpers", () => {
   // 🛠
 
 
-  it("can be combined", () => {
+  it("can create app-data paths", () => {
+    const appInfo = {
+      name: "Tests",
+      creator: "Fission"
+    }
+
+    const dir: DirectoryPath = Path.appData(
+      appInfo,
+      Path.directory("a")
+    )
+
     expect(
-      pathing.combine(
-        pathing.directory("a"),
-        pathing.directory("b")
-      )
+      dir
+    ).toEqual(
+      { directory: [ Path.Branch.Private, "Apps", appInfo.creator, appInfo.name, "a" ] }
+    )
+
+    const file: FilePath = Path.appData(
+      appInfo,
+      Path.file("a")
+    )
+
+    expect(
+      file
+    ).toEqual(
+      { file: [ Path.Branch.Private, "Apps", appInfo.creator, appInfo.name, "a" ] }
+    )
+  })
+
+
+  it("can be combined", () => {
+    const dir: DirectoryPath = Path.combine(
+      Path.directory("a"),
+      Path.directory("b")
+    )
+
+    expect(
+      dir
     ).toEqual(
       { directory: [ "a", "b" ] }
     )
 
+    const file: FilePath = Path.combine(
+      Path.directory("a"),
+      Path.file("b")
+    )
+
     expect(
-      pathing.combine(
-        pathing.directory("a"),
-        pathing.file("b")
-      )
+      file
     ).toEqual(
       { file: [ "a", "b" ] }
     )
@@ -124,16 +159,16 @@ describe("the path helpers", () => {
 
   it("supports isBranch", () => {
     expect(
-      pathing.isBranch(
-        pathing.Branch.Private,
-        pathing.directory(pathing.Branch.Private, "a")
+      Path.isBranch(
+        Path.Branch.Private,
+        Path.directory(Path.Branch.Private, "a")
       )
     ).toBe(true)
 
     expect(
-      pathing.isBranch(
-        pathing.Branch.Public,
-        pathing.directory(pathing.Branch.Private, "a")
+      Path.isBranch(
+        Path.Branch.Public,
+        Path.directory(Path.Branch.Private, "a")
       )
     ).toBe(false)
   })
@@ -141,14 +176,14 @@ describe("the path helpers", () => {
 
   it("supports isDirectory", () => {
     expect(
-      pathing.isDirectory(
-        pathing.directory(pathing.Branch.Private)
+      Path.isDirectory(
+        Path.directory(Path.Branch.Private)
       )
     ).toBe(true)
 
     expect(
-      pathing.isDirectory(
-        pathing.file("foo")
+      Path.isDirectory(
+        Path.file("foo")
       )
     ).toBe(false)
   })
@@ -156,14 +191,14 @@ describe("the path helpers", () => {
 
   it("supports isFile", () => {
     expect(
-      pathing.isFile(
-        pathing.file("foo")
+      Path.isFile(
+        Path.file("foo")
       )
     ).toBe(true)
 
     expect(
-      pathing.isFile(
-        pathing.directory(pathing.Branch.Private)
+      Path.isFile(
+        Path.directory(Path.Branch.Private)
       )
     ).toBe(false)
   })
@@ -171,20 +206,20 @@ describe("the path helpers", () => {
 
   it("supports isRootDirectory", () => {
     expect(
-      pathing.isRootDirectory(
-        pathing.root()
+      Path.isRootDirectory(
+        Path.root()
       )
     ).toBe(true)
 
     expect(
-      pathing.isRootDirectory(
-        pathing.directory()
+      Path.isRootDirectory(
+        Path.directory()
       )
     ).toBe(true)
 
     expect(
-      pathing.isRootDirectory(
-        pathing.directory(pathing.Branch.Private)
+      Path.isRootDirectory(
+        Path.directory(Path.Branch.Private)
       )
     ).toBe(false)
   })
@@ -192,16 +227,16 @@ describe("the path helpers", () => {
 
   it("supports isSameBranch", () => {
     expect(
-      pathing.isSameBranch(
-        pathing.directory(pathing.Branch.Private),
-        pathing.directory(pathing.Branch.Private)
+      Path.isSameBranch(
+        Path.directory(Path.Branch.Private),
+        Path.directory(Path.Branch.Private)
       )
     ).toBe(true)
 
     expect(
-      pathing.isSameBranch(
-        pathing.directory(pathing.Branch.Private),
-        pathing.directory(pathing.Branch.Public)
+      Path.isSameBranch(
+        Path.directory(Path.Branch.Private),
+        Path.directory(Path.Branch.Public)
       )
     ).toBe(false)
   })
@@ -209,30 +244,30 @@ describe("the path helpers", () => {
 
   it("supports isSameKind", () => {
     expect(
-      pathing.isSameKind(
-        pathing.directory(),
-        pathing.file()
+      Path.isSameKind(
+        Path.directory(),
+        Path.file()
       )
     ).toBe(false)
 
     expect(
-      pathing.isSameKind(
-        pathing.file(),
-        pathing.directory()
+      Path.isSameKind(
+        Path.file(),
+        Path.directory()
       )
     ).toBe(false)
 
     expect(
-      pathing.isSameKind(
-        pathing.directory(),
-        pathing.directory()
+      Path.isSameKind(
+        Path.directory(),
+        Path.directory()
       )
     ).toBe(true)
 
     expect(
-      pathing.isSameKind(
-        pathing.file(),
-        pathing.file()
+      Path.isSameKind(
+        Path.file(),
+        Path.file()
       )
     ).toBe(true)
   })
@@ -240,33 +275,33 @@ describe("the path helpers", () => {
 
   it("has kind", () => {
     expect(
-      pathing.kind(pathing.directory())
+      Path.kind(Path.directory())
     ).toEqual(
-      pathing.Kind.Directory
+      Path.Kind.Directory
     )
 
     expect(
-      pathing.kind(pathing.file())
+      Path.kind(Path.file())
     ).toEqual(
-      pathing.Kind.File
+      Path.Kind.File
     )
   })
 
 
   it("supports map", () => {
     expect(
-      pathing.map(
+      Path.map(
         p => [ ...p, "bar" ],
-        pathing.directory("foo")
+        Path.directory("foo")
       )
     ).toEqual(
       { directory: [ "foo", "bar" ] }
     )
 
     expect(
-      pathing.map(
+      Path.map(
         p => [ ...p, "bar" ],
-        pathing.file("foo")
+        Path.file("foo")
       )
     ).toEqual(
       { file: [ "foo", "bar" ] }
@@ -276,24 +311,24 @@ describe("the path helpers", () => {
 
   it("supports parent", () => {
     expect(
-      pathing.parent(
-        pathing.directory("foo")
+      Path.parent(
+        Path.directory("foo")
       )
     ).toEqual(
-      pathing.root()
+      Path.root()
     )
 
     expect(
-      pathing.parent(
-        pathing.file("foo")
+      Path.parent(
+        Path.file("foo")
       )
     ).toEqual(
-      pathing.root()
+      Path.root()
     )
 
     expect(
-      pathing.parent(
-        pathing.root()
+      Path.parent(
+        Path.root()
       )
     ).toEqual(
       null
@@ -303,35 +338,35 @@ describe("the path helpers", () => {
 
   it("supports removeBranch", () => {
     expect(
-      pathing.removeBranch(
-        pathing.directory("foo")
+      Path.removeBranch(
+        Path.directory("foo")
       )
     ).toEqual(
       { directory: [] }
     )
 
     expect(
-      pathing.removeBranch(
-        pathing.directory("foo", "bar")
+      Path.removeBranch(
+        Path.directory("foo", "bar")
       )
     ).toEqual(
-      pathing.directory("bar")
+      Path.directory("bar")
     )
   })
 
 
   it("correctly unwraps", () => {
     expect(
-      pathing.unwrap(
-        pathing.directory("foo")
+      Path.unwrap(
+        Path.directory("foo")
       )
     ).toEqual(
       [ "foo" ]
     )
 
     expect(
-      pathing.unwrap(
-        pathing.file("foo")
+      Path.unwrap(
+        Path.file("foo")
       )
     ).toEqual(
       [ "foo" ]

--- a/src/path/index.node.test.ts
+++ b/src/path/index.node.test.ts
@@ -108,6 +108,16 @@ describe("the path helpers", () => {
       creator: "Fission"
     }
 
+    const root: DirectoryPath = Path.appData(
+      appInfo
+    )
+
+    expect(
+      root
+    ).toEqual(
+      { directory: [ Path.Branch.Private, "Apps", appInfo.creator, appInfo.name ] }
+    )
+
     const dir: DirectoryPath = Path.appData(
       appInfo,
       Path.directory("a")

--- a/src/path/index.ts
+++ b/src/path/index.ts
@@ -62,9 +62,11 @@ export function root(): DirectoryPath {
 /**
  * Utility function create an app data path.
  */
-export function appData(app: AppInfo, suffix?: DistinctivePath): DistinctivePath {
+export function appData(app: AppInfo, suffix?: FilePath): FilePath
+export function appData(app: AppInfo, suffix?: DirectoryPath): DirectoryPath
+export function appData(app: AppInfo, suffix?: DistinctivePath): DistinctivePath
+export function appData(app: AppInfo, suffix?: any): any {
   const parent = directory(Branch.Private, "Apps", app.creator, app.name)
-
   if (suffix) return combine(parent, suffix)
   return parent
 }

--- a/src/path/index.ts
+++ b/src/path/index.ts
@@ -62,9 +62,10 @@ export function root(): DirectoryPath {
 /**
  * Utility function create an app data path.
  */
-export function appData(app: AppInfo, suffix?: FilePath): FilePath
-export function appData(app: AppInfo, suffix?: DirectoryPath): DirectoryPath
-export function appData(app: AppInfo, suffix?: DistinctivePath): DistinctivePath
+export function appData(app: AppInfo): DirectoryPath
+export function appData(app: AppInfo, suffix: FilePath): FilePath
+export function appData(app: AppInfo, suffix: DirectoryPath): DirectoryPath
+export function appData(app: AppInfo, suffix: DistinctivePath): DistinctivePath
 export function appData(app: AppInfo, suffix?: any): any {
   const parent = directory(Branch.Private, "Apps", app.creator, app.name)
   if (suffix) return combine(parent, suffix)


### PR DESCRIPTION
`webnative.path.appData` was missing the correct function overload type signatures, causing it always to return a path of the type `DistinctivePath` instead of specifically `FilePath` or `DirectoryPath` depending what type of suffix path you give it (if any).

```ts
const root: DirectoryPath = wn.path.appData(appInfo)
const dir: DirectoryPath = wn.path.appData(appInfo, wn.path.directory("example"))
const file: FilePath = wn.path.appData(appInfo, wn.path.file("example.txt"))
```