### PR TITLE
Use better trigger for docs Github action

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,10 +1,8 @@
 name: Docs
 
 on:
-  push:
-    branches:
-      - 'releases/**'
-      - '!releases/**-alpha'
+  release:
+    types: [released]
 
   workflow_dispatch:
 


### PR DESCRIPTION
This will cause the docs site to update whenever a "stable" Github release is created. I first had the idea to do `releases/*` branches to trigger the docs but that was never done, and instead triggered the action manually.