### PR TITLE
Avivash/File System Recovery Shorthand Method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### v0.35.2
 
+Adds `program.recoverFileSystem({ newUsername, oldUsername, readKey })` shorthand method so apps will no longer have to implement the FS recovery flow manually.
+
+### v0.35.2
+
 Fixes issue with the types of the `path.appData` function. Now has the correct overloads.
 
 ### v0.35.1
@@ -354,7 +358,7 @@ Upgrade to CIDv1.
   });
   ```
 
-- Those prerequisites are passed to the `wn.redirectToLobby` function.  
+- Those prerequisites are passed to the `wn.redirectToLobby` function.
   (So the auth lobby has the correct parameters to determine the permissions to ask the user)
 - Adds the ability to use multiple apps with one file system (closes #73)
 - The SDK now handles multiple UCANs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### v0.35.3
+### v0.36.0
 
 Adds `program.recoverFileSystem({ newUsername, oldUsername, readKey })` shorthand method so apps will no longer have to implement the FS recovery flow manually.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### v0.35.2
+### v0.35.3
 
 Adds `program.recoverFileSystem({ newUsername, oldUsername, readKey })` shorthand method so apps will no longer have to implement the FS recovery flow manually.
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ __Notes:__
 - You can use alternative authentication strategies, such as [webnative-walletauth](https://github.com/fission-codes/webnative-walletauth).
 - You can remove all traces of the user using `await session.destroy()`
 - You can load the file system separately if you're using a web worker. This is done using the combination of `configuration.fileSystem.loadImmediately = false` and `program.loadFileSystem()`
-- You can recover a file system if you've downloaded a Recovery Kit by calling `program.recoverFileSystem({ newUsername, oldUsername, readKey })`. The `oldUsername` and `readKey` can be parsed from the uploaded Recovery Kit and the `newUsername` can be generated before calling the function. Please refer to [this example](https://github.com/webnative-examples/webnative-app-template/blob/5498e7062a4578028b8b55d2ac4c611bd5daab85/src/components/auth/recover/HasRecoveryKit.svelte#L49) from Fission's Webnative App Template
+- You can recover a file system if you've downloaded a Recovery Kit by calling `program.recoverFileSystem({ newUsername, oldUsername, readKey })`. The `oldUsername` and `readKey` can be parsed from the uploaded Recovery Kit and the `newUsername` can be generated before calling the function. Please refer to [this example](https://github.com/webnative-examples/webnative-app-template/blob/5498e7062a4578028b8b55d2ac4c611bd5daab85/src/components/auth/recover/HasRecoveryKit.svelte#L49) from Fission's Webnative App Template. Additionally, if you would like to see how to generate a Recovery Kit, you can reference [this example](https://github.com/webnative-examples/webnative-app-template/blob/main/src/lib/account-settings.ts#L186)
 
 
 ## Working with the file system

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ __Notes:__
 - You can use alternative authentication strategies, such as [webnative-walletauth](https://github.com/fission-codes/webnative-walletauth).
 - You can remove all traces of the user using `await session.destroy()`
 - You can load the file system separately if you're using a web worker. This is done using the combination of `configuration.fileSystem.loadImmediately = false` and `program.loadFileSystem()`
+- You can recover a file system if you've downloaded a Recovery Kit by calling `program.recoverFileSystem({ newUsername, oldUsername, readKey })`. The `oldUsername` and `readKey` can be parsed from the uploaded Recovery Kit and the `newUsername` can be generated before calling the function. Please refer to [this example](https://github.com/webnative-examples/webnative-app-template/blob/5498e7062a4578028b8b55d2ac4c611bd5daab85/src/components/auth/recover/HasRecoveryKit.svelte#L49) from Fission's Webnative App Template
 
 
 ## Working with the file system

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -1,26 +1,23 @@
 import { CID } from "multiformats/cid"
 
+import * as Crypto from "./components/crypto/implementation.js"
 import * as Depot from "./components/depot/implementation.js"
-import * as Reference from "./components/reference/implementation.js"
-
+import * as DID from "./did/index.js"
 import * as Protocol from "./fs/protocol/index.js"
+import * as Reference from "./components/reference/implementation.js"
+import * as RootKey from "./common/root-key.js"
+import * as Storage from "./components/storage/implementation.js"
+import * as Ucan from "./ucan/index.js"
 import * as Versions from "./fs/versions.js"
 
-import FileSystem, { Dependencies } from "./fs/filesystem.js"
-
-import * as Ucan from "./ucan/index.js"
-
-import * as RootKey from "./common/root-key.js"
-
-import * as DID from "./did/index.js"
-
+import { AuthenticationStrategy } from "./index.js"
 import { Branch } from "./path/index.js"
 import { Configuration } from "./configuration.js"
+import { Dependencies } from "./fs/filesystem.js"
 import { Maybe, decodeCID, EMPTY_CID } from "./common/index.js"
-
 import { type RecoverFileSystemParams } from "./fs/types/params.js"
 
-import { AuthenticationStrategy } from "./index.js"
+import FileSystem from "./fs/filesystem.js"
 
 
 /**
@@ -120,15 +117,18 @@ export async function loadFileSystem({ config, dependencies, rootKey, username }
  */
 export async function recoverFileSystem({
   auth,
-  dependencies,
   oldUsername,
   newUsername,
   readKey,
 }: {
   auth: AuthenticationStrategy
-  dependencies: Dependencies
 } & RecoverFileSystemParams): Promise<{ success: boolean }> {
 
+  const dependencies = {
+    crypto: Crypto,
+    reference: Reference,
+    storage: Storage,
+  }
   const { crypto, reference, storage } = dependencies
 
   const newRootDID = await DID.agent(dependencies.crypto)

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -10,7 +10,7 @@ import FileSystem, { Dependencies } from "./fs/filesystem.js"
 
 import * as Ucan from "./ucan/index.js"
 
-import * as RootKey from "./common/root-key"
+import * as RootKey from "./common/root-key.js"
 
 import { Branch } from "./path/index.js"
 import { Configuration } from "./configuration.js"

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -142,7 +142,9 @@ export async function recoverFileSystem({
     }
 
     // Build an ephemeral UCAN to authorize the dataRoot.update call
-    const proof: string | null = await storage.getItem(storage.KEYS.ACCOUNT_UCAN)
+    const proof: string | null = await storage.getItem(
+      storage.KEYS.ACCOUNT_UCAN
+    )
     const ucan = await Ucan.build({
       dependencies,
       potency: "APPEND",
@@ -161,7 +163,7 @@ export async function recoverFileSystem({
     // Update the dataRoot of the new user
     await reference.dataRoot.update(oldRootCID, ucan)
 
-    // Store the accountDID, which is used to namespace the readKey
+    // Store the read key, which is namespaced using the account DID
     await RootKey.store({
       accountDID: newRootDID,
       crypto: crypto,
@@ -169,7 +171,7 @@ export async function recoverFileSystem({
     })
 
     return {
-      success: true
+      success: true,
     }
   } catch (error) {
     return {

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -117,21 +117,22 @@ export async function loadFileSystem({ config, dependencies, rootKey, username }
  */
 export async function recoverFileSystem({
   auth,
+  dependencies,
   oldUsername,
   newUsername,
   readKey,
 }: {
   auth: AuthenticationStrategy
+  dependencies: {
+    crypto: Crypto.Implementation
+    reference: Reference.Implementation
+    storage: Storage.Implementation
+  }
 } & RecoverFileSystemParams): Promise<{ success: boolean }> {
 
-  const dependencies = {
-    crypto: Crypto,
-    reference: Reference,
-    storage: Storage,
-  }
   const { crypto, reference, storage } = dependencies
 
-  const newRootDID = await DID.agent(dependencies.crypto)
+  const newRootDID = await DID.agent(crypto)
 
   // Register a new user with the `newUsername`
   const { success } = await auth.register({
@@ -142,9 +143,7 @@ export async function recoverFileSystem({
   }
 
   // Build an ephemeral UCAN to authorize the dataRoot.update call
-  const proof: string | null = await storage.getItem(
-    storage.KEYS.ACCOUNT_UCAN
-  )
+  const proof: string | null = await storage.getItem(storage.KEYS.ACCOUNT_UCAN)
   const ucan = await Ucan.build({
     dependencies,
     potency: "APPEND",

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -1,4 +1,3 @@
-import * as uint8arrays from "uint8arrays"
 import { CID } from "multiformats/cid"
 
 import * as Depot from "./components/depot/implementation.js"
@@ -18,6 +17,7 @@ import { Configuration } from "./configuration.js"
 import { Maybe, decodeCID, EMPTY_CID } from "./common/index.js"
 
 import { type RecoverFileSystemParams } from "./fs/types/params"
+
 import { AuthenticationStrategy } from "./index.js"
 
 

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -16,7 +16,7 @@ import { Branch } from "./path/index.js"
 import { Configuration } from "./configuration.js"
 import { Maybe, decodeCID, EMPTY_CID } from "./common/index.js"
 
-import { type RecoverFileSystemParams } from "./fs/types/params"
+import { type RecoverFileSystemParams } from "./fs/types/params.js"
 
 import { AuthenticationStrategy } from "./index.js"
 

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -12,6 +12,8 @@ import * as Ucan from "./ucan/index.js"
 
 import * as RootKey from "./common/root-key.js"
 
+import * as DID from "./did/index.js"
+
 import { Branch } from "./path/index.js"
 import { Configuration } from "./configuration.js"
 import { Maybe, decodeCID, EMPTY_CID } from "./common/index.js"
@@ -117,21 +119,19 @@ export async function loadFileSystem({ config, dependencies, rootKey, username }
  * Recover a user's file system.
  */
 export async function recoverFileSystem({
-  agentDID,
   auth,
   dependencies,
   oldUsername,
   newUsername,
   readKey,
 }: {
-  agentDID: () => Promise<string>
   auth: AuthenticationStrategy
   dependencies: Dependencies
 } & RecoverFileSystemParams): Promise<{ success: boolean }> {
   try {
     const { crypto, reference, storage } = dependencies
 
-    const newRootDID = await agentDID()
+    const newRootDID = await DID.agent(dependencies.crypto)
 
     // Register a new user with the `newUsername`
     const { success } = await auth.register({

--- a/src/fs/types/params.ts
+++ b/src/fs/types/params.ts
@@ -1,0 +1,5 @@
+export type RecoverFileSystemParams = {
+  newUsername: string
+  oldUsername: string
+  readKey: Uint8Array
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,7 @@ import FileSystem from "./fs/filesystem.js"
 // TYPES
 
 
-import { type RecoverFileSystemParams } from "./fs/types/params"
+import { type RecoverFileSystemParams } from "./fs/types/params.js"
 
 
 // IMPLEMENTATIONS

--- a/src/index.ts
+++ b/src/index.ts
@@ -495,7 +495,7 @@ export async function assemble(config: Configuration, components: Components): P
   }
 
   // AgentDID
-  const agentDID = async () => DID.agent(components.crypto)
+  const agentDID = () => DID.agent(components.crypto)
 
   // Shorthands
   const shorthands: ShortHands = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -494,13 +494,16 @@ export async function assemble(config: Configuration, components: Components): P
 
   }
 
+  // AgentDID
+  const agentDID = async () => DID.agent(components.crypto)
+
   // Shorthands
   const shorthands: ShortHands = {
     loadFileSystem: (username: string) =>
       loadFileSystem({ config, username, dependencies: components }),
     recoverFileSystem: (params: RecoverFileSystemParams) =>
-      recoverFileSystem({ agentDID: () => DID.agent(components.crypto), auth, dependencies: components, ...params }),
-    agentDID: () => DID.agent(components.crypto),
+      recoverFileSystem({ agentDID, auth, dependencies: components, ...params }),
+    agentDID,
     sharingDID: () => DID.sharing(components.crypto),
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,11 +49,18 @@ import { Components } from "./components.js"
 import { Configuration, namespace } from "./configuration.js"
 import { isString, Maybe } from "./common/index.js"
 import { Session } from "./session.js"
-import { loadFileSystem } from "./filesystem.js"
+import { loadFileSystem, recoverFileSystem } from "./filesystem.js"
 import FileSystem from "./fs/filesystem.js"
 
 
+// TYPES
+
+
+import { type RecoverFileSystemParams } from "./fs/types/params"
+
+
 // IMPLEMENTATIONS
+
 
 import * as BaseAuth from "./components/auth/implementation/base.js"
 import * as BaseReference from "./components/reference/implementation/base.js"
@@ -143,9 +150,13 @@ export enum ProgramError {
   UnsupportedBrowser = "UNSUPPORTED_BROWSER"
 }
 
-
 export type ShortHands = {
   loadFileSystem: (username: string) => Promise<FileSystem>
+  recoverFileSystem: ({
+    newUsername,
+    oldUsername,
+    readKey,
+  }: RecoverFileSystemParams) => Promise<{ success: boolean }>
   agentDID: () => Promise<string>
   sharingDID: () => Promise<string>
 }
@@ -485,8 +496,10 @@ export async function assemble(config: Configuration, components: Components): P
 
   // Shorthands
   const shorthands: ShortHands = {
-    loadFileSystem: (username: string) => loadFileSystem({ config, username, dependencies: components }),
-
+    loadFileSystem: (username: string) =>
+      loadFileSystem({ config, username, dependencies: components }),
+    recoverFileSystem: (params: RecoverFileSystemParams) =>
+      recoverFileSystem({ agentDID: () => DID.agent(components.crypto), auth, dependencies: components, ...params }),
     agentDID: () => DID.agent(components.crypto),
     sharingDID: () => DID.sharing(components.crypto),
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -501,7 +501,7 @@ export async function assemble(config: Configuration, components: Components): P
     recoverFileSystem: (params: RecoverFileSystemParams) =>
       recoverFileSystem({
         auth,
-        dependencies: components,
+        dependencies: { crypto: components.crypto, reference: components.reference, storage: components.storage },
         ...params,
       }),
     agentDID: () => DID.agent(components.crypto),

--- a/src/index.ts
+++ b/src/index.ts
@@ -494,16 +494,17 @@ export async function assemble(config: Configuration, components: Components): P
 
   }
 
-  // AgentDID
-  const agentDID = () => DID.agent(components.crypto)
-
   // Shorthands
   const shorthands: ShortHands = {
     loadFileSystem: (username: string) =>
       loadFileSystem({ config, username, dependencies: components }),
     recoverFileSystem: (params: RecoverFileSystemParams) =>
-      recoverFileSystem({ agentDID, auth, dependencies: components, ...params }),
-    agentDID,
+      recoverFileSystem({
+        auth,
+        dependencies: components,
+        ...params,
+      }),
+    agentDID: () => DID.agent(components.crypto),
     sharingDID: () => DID.sharing(components.crypto),
   }
 


### PR DESCRIPTION
## Summary

This PR fixes/implements the following **bugs/features**

* [x] The `recoverFileSystem` shorthand

Moving the FileSystem recovery functionality into `webnative`. Devs can now call the `recoverFileSystem` shorthand method directly from the `program`. It is important to note the `newUsername` and `oldUsername` that are passed in are the hashed versions, as `webnative` doesn't yet have a notion of the unhashed versions. (That will be completed in https://github.com/fission-codes/webnative/issues/385)

```ts
const { success } = await $sessionStore.program.recoverFileSystem({
  newUsername,
  oldUsername,
  readKey
})
```

~~**Note: I'm not sure if we currently have the infrastructure in the codebase for this, but it would be cool if we could emit events at various parts of the recovery flow to update the message on the client 🤔**~~ Answered by Steven!

## Test plan (required)

Load [WAT](https://github.com/webnative-examples/webnative-app-template/) using this `webnative` branch and go through the recovery flow. It should work the same as it did before.

https://www.loom.com/share/b2ecfe8fa8a04f7e96dab76d8dc749a6

## Closing issues

Closes https://github.com/fission-codes/webnative/issues/427

## After Merge
* [ ] Does this change invalidate any docs or tutorials? _If so ensure the changes needed are either made or recorded_
* [x] Does this change require a release to be made? Is so please create and deploy the release

## Sibling PR

https://github.com/webnative-examples/webnative-app-template/pull/113
