### PR TITLE
Add shorthand accountDID method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### v0.36.0
 
-Adds `program.recoverFileSystem({ newUsername, oldUsername, readKey })` shorthand method so apps will no longer have to implement the FS recovery flow manually.
+- Adds `program.recoverFileSystem({ newUsername, oldUsername, readKey })` shorthand method so apps will no longer have to implement the FS recovery flow manually.
+- Adds `program.accountDID(username)` shorthand method to retrieve the root DID of a given account username.
 
 ### v0.35.2
 

--- a/tests/helpers/filesystem.ts
+++ b/tests/helpers/filesystem.ts
@@ -3,7 +3,7 @@ import { CID } from "multiformats/cid"
 import * as Identifiers from "../../src/common/identifiers.js"
 import * as Path from "../../src/path/index.js"
 import FileSystem from "../../src/fs/filesystem.js"
-import { account, components, configuration, crypto } from "./components.js"
+import { account, components, crypto } from "./components.js"
 
 
 export function emptyFilesystem(version?: string): Promise<FileSystem> {

--- a/tests/index.node.test.ts
+++ b/tests/index.node.test.ts
@@ -1,0 +1,13 @@
+import expect from "expect"
+import * as DID from "../src/did/index.js"
+import * as Webnative from "../src/index.js"
+import { components, configuration, username } from "./helpers/components.js"
+
+
+describe("accountDID shorthand", async () => {
+  const program = await Webnative.assemble(configuration, { ...components })
+
+  expect(await program.accountDID(username)).toEqual(
+    await DID.write(components.crypto)
+  )
+})


### PR DESCRIPTION
Closes #443

```ts
program.accountDID(username)
```
I thought about doing just `program.accountDID()` without the username param which would depend on the session underneath and return `null` if not authed. But seeing that `loadFileSystem` also takes the `username` parameter, it makes sense to implement it that way.