### PR TITLE
Use stricter types for path creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 - Adds `program.accountDID(username)` shorthand method to retrieve the root DID of a given account username.
 - Adds the file system data functions as shorthand methods.
 
+#### Other
+
+- Introduces stricter types for paths to restrict the paths you can use with various functions and also to guide you a bit more.
+
 
 ### v0.35.2
 

--- a/src/capabilities.ts
+++ b/src/capabilities.ts
@@ -28,7 +28,7 @@ export type Capabilities = {
 
 export type FileSystemSecret = {
   bareNameFilter: string
-  path: Path.DistinctivePath
+  path: Path.Distinctive<Path.Segments>
   readKey: Uint8Array
 }
 
@@ -77,7 +77,7 @@ export async function collectSecret({ accountDID, bareNameFilter, crypto, path, 
   accountDID: string
   bareNameFilter: string
   crypto: Crypto.Implementation
-  path: Path.DistinctivePath
+  path: Path.DistinctivePath<Path.Segments>
   readKey: Uint8Array
   storage: Storage.Implementation
 }) {
@@ -166,7 +166,7 @@ export async function validateSecrets(
   permissions: Permissions.Permissions
 ): Promise<boolean> {
   return Permissions.permissionPaths(permissions).reduce(
-    (acc: Promise<boolean>, path: Path.DistinctivePath): Promise<boolean> =>
+    (acc: Promise<boolean>, path: Path.Distinctive<Path.Branched>): Promise<boolean> =>
       acc.then(async (bool: boolean) => {
         if (bool === false) return bool
         if (Path.isBranch(Path.Branch.Public, path)) return bool

--- a/src/capabilities.ts
+++ b/src/capabilities.ts
@@ -166,10 +166,10 @@ export async function validateSecrets(
   permissions: Permissions.Permissions
 ): Promise<boolean> {
   return Permissions.permissionPaths(permissions).reduce(
-    (acc: Promise<boolean>, path: Path.Distinctive<Path.Branched>): Promise<boolean> =>
+    (acc: Promise<boolean>, path: Path.Distinctive<Path.Partitioned<Path.Partition>>): Promise<boolean> =>
       acc.then(async (bool: boolean) => {
         if (bool === false) return bool
-        if (Path.isBranch(Path.Branch.Public, path)) return bool
+        if (Path.isPartition(Path.RootBranch.Public, path)) return bool
 
         const keyName = await Identifiers.readKey({ accountDID, crypto, path })
         return crypto.keystore.keyExists(keyName)

--- a/src/common/identifiers.ts
+++ b/src/common/identifiers.ts
@@ -9,7 +9,7 @@ import * as Path from "../path/index.js"
 type Arguments = {
   crypto: Crypto.Implementation
   accountDID: string
-  path: DistinctivePath
+  path: DistinctivePath<Path.Segments>
 }
 
 
@@ -30,7 +30,7 @@ export async function readKey(
 // 🛠
 
 
-async function pathHash(crypto: Crypto.Implementation, path: DistinctivePath): Promise<string> {
+async function pathHash(crypto: Crypto.Implementation, path: DistinctivePath<Path.Segments>): Promise<string> {
   return Uint8Arrays.toString(
     await crypto.hash.sha256(
       Uint8Arrays.fromString("/" + Path.unwrap(path).join("/"), "utf8")

--- a/src/common/root-key.ts
+++ b/src/common/root-key.ts
@@ -55,6 +55,6 @@ export function toString(a: Uint8Array): string {
 
 
 function identifier(crypto: Crypto.Implementation, accountDID: string): Promise<string> {
-  const path = Path.directory(Path.Branch.Private)
+  const path = Path.directory(Path.RootBranch.Private)
   return Identifiers.readKey({ crypto, path, accountDID })
 }

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -11,7 +11,7 @@ import * as Ucan from "./ucan/index.js"
 import * as Versions from "./fs/versions.js"
 
 import { AuthenticationStrategy } from "./index.js"
-import { Branch } from "./path/index.js"
+import { RootBranch } from "./path/index.js"
 import { Configuration } from "./configuration.js"
 import { Dependencies } from "./fs/filesystem.js"
 import { Maybe, decodeCID, EMPTY_CID } from "./common/index.js"
@@ -194,12 +194,12 @@ export async function checkFileSystemVersion(
   const links = await Protocol.basic.getSimpleLinks(depot, filesystemCID)
   // if there's no version link, we assume it's from a 1.0.0-compatible version
   // (from before ~ November 2020)
-  const versionStr = links[ Branch.Version ] == null
+  const versionStr = links[ RootBranch.Version ] == null
     ? "1.0.0"
     : new TextDecoder().decode(
       await Protocol.basic.getFile(
         depot,
-        decodeCID(links[ Branch.Version ].cid)
+        decodeCID(links[ RootBranch.Version ].cid)
       )
     )
 

--- a/src/fs/bare/tree.ts
+++ b/src/fs/bare/tree.ts
@@ -8,7 +8,7 @@ import * as Link from "../link.js"
 import { HardLinks, BaseLinks, Tree, File, Puttable, UpdateCallback, PuttableUnixTree } from "../types.js"
 import { Maybe, decodeCID } from "../../common/index.js"
 import { isObject, hasProp } from "../../common/type-checks.js"
-import { Path } from "../../path/index.js"
+import { Segments as Path } from "../../path/index.js"
 
 import BareFile from "../bare/file.js"
 import BaseTree from "../base/tree.js"

--- a/src/fs/base/tree.ts
+++ b/src/fs/base/tree.ts
@@ -4,7 +4,7 @@ import * as Check from "../types/check.js"
 import * as Pathing from "../../path/index.js"
 
 import { Maybe } from "../../common/index.js"
-import { Path } from "../../path/index.js"
+import { Segments as Path } from "../../path/index.js"
 import { PutResult } from "../../components/depot/implementation.js"
 import { Tree, File, UnixTree, Links, UpdateCallback } from "../types.js"
 

--- a/src/fs/data.ts
+++ b/src/fs/data.ts
@@ -5,22 +5,20 @@ import * as FileSystem from "../fs/types.js"
 import * as Path from "../path/index.js"
 import * as Sharing from "./share.js"
 
-import { Branch } from "../path/index.js"
-
 
 /**
  * Adds some sample to the file system.
  */
 export async function addSampleData(fs: FileSystem.API): Promise<void> {
-  await fs.mkdir(Path.directory(Branch.Private, "Apps"))
-  await fs.mkdir(Path.directory(Branch.Private, "Audio"))
-  await fs.mkdir(Path.directory(Branch.Private, "Documents"))
-  await fs.mkdir(Path.directory(Branch.Private, "Photos"))
-  await fs.mkdir(Path.directory(Branch.Private, "Video"))
+  await fs.mkdir(Path.directory("private", "Apps"))
+  await fs.mkdir(Path.directory("private", "Audio"))
+  await fs.mkdir(Path.directory("private", "Documents"))
+  await fs.mkdir(Path.directory("private", "Photos"))
+  await fs.mkdir(Path.directory("private", "Video"))
 
   // Files
   await fs.write(
-    Path.file(Branch.Private, "Welcome.txt"),
+    Path.file("private", "Welcome.txt"),
     new TextEncoder().encode("Welcome to your personal transportable encrypted file system 👋")
   )
 }

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -16,7 +16,7 @@ import * as TypeChecks from "../common/type-checks.js"
 import * as Ucan from "../ucan/index.js"
 import * as Versions from "./versions.js"
 
-import { Branch, Branched, DistinctivePath, DirectoryPath, FilePath } from "../path/index.js"
+import { RootBranch, Partitioned, PartitionedNonEmpty, Partition, DistinctivePath } from "../path/index.js"
 import { Permissions } from "../permissions.js"
 import { SymmAlg } from "../components/crypto/implementation.js"
 import { decodeCID } from "../common/index.js"
@@ -204,7 +204,7 @@ export class FileSystem implements API {
   // POSIX INTERFACE (DIRECTORIES)
   // -----------------------------
 
-  async ls(path: Path.Directory<Branched>): Promise<Links> {
+  async ls(path: Path.Directory<Partitioned<Partition>>): Promise<Links> {
     if (Path.isFile(path)) throw new Error("`ls` only accepts directory paths")
     return this.runOnNode(path, {
       public: async (root, relPath) => {
@@ -220,7 +220,7 @@ export class FileSystem implements API {
     })
   }
 
-  async mkdir(path: Path.Directory<Branched>, options: MutationOptions = {}): Promise<this> {
+  async mkdir(path: Path.Directory<PartitionedNonEmpty<Partition>>, options: MutationOptions = {}): Promise<this> {
     if (Path.isFile(path)) throw new Error("`mkdir` only accepts directory paths")
 
     await this.runMutationOnNode(path, {
@@ -246,7 +246,7 @@ export class FileSystem implements API {
   // -----------------------
 
   async write(
-    path: Path.Distinctive<Branched>,
+    path: Path.Distinctive<PartitionedNonEmpty<Partition>>,
     content: Uint8Array | SoftLink | SoftLink[] | Record<string, SoftLink>,
     options: MutationOptions = {}
   ): Promise<this> {
@@ -326,7 +326,7 @@ export class FileSystem implements API {
     return this
   }
 
-  async read(path: Path.File<Branched>): Promise<Uint8Array> {
+  async read(path: Path.File<PartitionedNonEmpty<Partition>>): Promise<Uint8Array> {
     if (Path.isDirectory(path)) throw new Error("`cat` only accepts file paths")
     return this.runOnNode(path, {
       public: async (root, relPath) => {
@@ -344,7 +344,7 @@ export class FileSystem implements API {
   // POSIX INTERFACE (GENERAL)
   // -------------------------
 
-  async exists(path: Path.Distinctive<Branched>): Promise<boolean> {
+  async exists(path: Path.Distinctive<PartitionedNonEmpty<Partition>>): Promise<boolean> {
     return this.runOnNode(path, {
       public: async (root, relPath) => {
         return await root.exists(relPath)
@@ -356,7 +356,7 @@ export class FileSystem implements API {
     })
   }
 
-  async get(path: Path.Distinctive<Branched>): Promise<PuttableUnixTree | File | null> {
+  async get(path: Path.Distinctive<Partitioned<Partition>>): Promise<PuttableUnixTree | File | null> {
     return this.runOnNode(path, {
       public: async (root, relPath) => {
         return await root.get(relPath)
@@ -370,8 +370,8 @@ export class FileSystem implements API {
   }
 
   // This is only implemented on the same tree for now and will error otherwise
-  async mv(from: Path.Distinctive<Branched>, to: Path.Distinctive<Branched>): Promise<this> {
-    const sameTree = Path.isSameBranch(from, to)
+  async mv(from: Path.Distinctive<PartitionedNonEmpty<Partition>>, to: Path.Distinctive<PartitionedNonEmpty<Partition>>): Promise<this> {
+    const sameTree = Path.isSamePartition(from, to)
 
     if (!Path.isSameKind(from, to)) {
       const kindFrom = Path.kind(from)
@@ -420,7 +420,7 @@ export class FileSystem implements API {
     }
   }
 
-  async rm(path: DistinctivePath<Branched>): Promise<this> {
+  async rm(path: DistinctivePath<Partitioned<Partition>>): Promise<this> {
     await this.runMutationOnNode(path, {
       public: async (root, relPath) => {
         await root.rm(relPath)
@@ -442,7 +442,7 @@ export class FileSystem implements API {
    */
   async symlink(
     args:
-      { at: Path.Directory<Branched>; referringTo: Path.Distinctive<Branched>; name: string }
+      { at: Path.Directory<Partitioned<Partition>>; referringTo: Path.Distinctive<Partitioned<Partition>>; name: string }
   ): Promise<this> {
     const { at, referringTo, name } = args
     const username = this.account.username
@@ -450,7 +450,7 @@ export class FileSystem implements API {
     if (at == null) throw new Error("Missing parameter `symlink.at`")
     if (Path.isFile(at)) throw new Error("`symlink.at` only accepts directory paths")
 
-    const sameTree = Path.isSameBranch(at, referringTo)
+    const sameTree = Path.isSamePartition(at, referringTo)
 
     if (!username) throw new Error("I need a username in order to use this method")
     if (!sameTree) throw new Error("`link` is only supported on the same tree for now")
@@ -466,7 +466,7 @@ export class FileSystem implements API {
           await this.runOnChildTree(root, relPath, async tree => {
             if (PublicTree.instanceOf(tree)) {
               tree.insertSoftLink({
-                path: Path.removeBranch(referringTo),
+                path: Path.removePartition(referringTo),
                 name,
                 username,
               })
@@ -569,7 +569,7 @@ export class FileSystem implements API {
   async acceptShare({ shareId, sharedBy }: { shareId: string; sharedBy: string }): Promise<this> {
     const share = await this.loadShare({ shareId, sharedBy })
     await this.write(
-      Path.directory(Branch.Private, "Shared with me", sharedBy),
+      Path.directory(RootBranch.Private, "Shared with me", sharedBy),
       await share.ls([]).then(Object.values).then(links => links.filter(FsTypeChecks.isSoftLink))
     )
     return this
@@ -596,7 +596,7 @@ export class FileSystem implements API {
     if (!root) throw new Error("This user doesn't have a filesystem yet.")
 
     const rootLinks = await Protocol.basic.getSimpleLinks(this.dependencies.depot, root)
-    const sharedLinksCid = rootLinks[ Branch.Shared ]?.cid || null
+    const sharedLinksCid = rootLinks[ RootBranch.Shared ]?.cid || null
     if (!sharedLinksCid) throw new Error("This user hasn't shared anything yet.")
 
     const sharedLinks = await RootTree.getSharedLinks(this.dependencies.depot, decodeCID(sharedLinksCid))
@@ -621,11 +621,11 @@ export class FileSystem implements API {
     const symmKeyAlgo: string = decodedPayload.algo as string
 
     // Load MMPT
-    const mmptCid = rootLinks[ Branch.Private ]?.cid
+    const mmptCid = rootLinks[ RootBranch.Private ]?.cid
     if (!mmptCid) throw new Error("This user's filesystem doesn't have a private branch")
     const theirMmpt = await MMPT.fromCID(
       this.dependencies.depot,
-      decodeCID(rootLinks[ Branch.Private ]?.cid)
+      decodeCID(rootLinks[ RootBranch.Private ]?.cid)
     )
 
     // Decode index
@@ -648,9 +648,9 @@ export class FileSystem implements API {
   /**
    * Share a private file with a user.
    */
-  async sharePrivate(paths: Path.Distinctive<Path.Private>[], { sharedBy, shareWith }: { sharedBy?: SharedBy; shareWith: string | string[] }): Promise<ShareDetails> {
+  async sharePrivate(paths: Path.Distinctive<Path.PartitionedNonEmpty<Path.Private>>[], { sharedBy, shareWith }: { sharedBy?: SharedBy; shareWith: string | string[] }): Promise<ShareDetails> {
     const verifiedPaths = paths.filter(path => {
-      return Path.isBranch(Path.Branch.Private, path)
+      return Path.isRootBranch(Path.RootBranch.Private, path)
     })
 
     // Our username
@@ -687,7 +687,7 @@ export class FileSystem implements API {
     await this.root.bumpSharedCounter()
 
     // Publish
-    await this.root.updatePuttable(Branch.Private, this.root.mmpt)
+    await this.root.updatePuttable(RootBranch.Private, this.root.mmpt)
     await this.publish()
 
     // Fin
@@ -699,7 +699,7 @@ export class FileSystem implements API {
   // --------
 
   /** @internal */
-  async checkMutationPermissionAndAddProof(path: DistinctivePath<Branched>, isMutation: boolean): Promise<void> {
+  async checkMutationPermissionAndAddProof(path: DistinctivePath<Partitioned<Partition>>, isMutation: boolean): Promise<void> {
     const operation = isMutation ? "make changes to" : "query"
 
     if (!this.localOnly) {
@@ -715,7 +715,7 @@ export class FileSystem implements API {
 
   /** @internal */
   async runMutationOnNode(
-    path: DistinctivePath<Branched>,
+    path: DistinctivePath<Partitioned<Partition>>,
     handlers: {
       public(root: UnixTree, relPath: Path.Segments): Promise<void>
       private(node: PrivateTree | PrivateFile, relPath: Path.Segments): Promise<void>
@@ -727,16 +727,16 @@ export class FileSystem implements API {
 
     await this.checkMutationPermissionAndAddProof(path, true)
 
-    if (head === Branch.Public) {
+    if (head === RootBranch.Public) {
       await handlers.public(this.root.publicTree, relPath)
       await handlers.public(this.root.prettyTree, relPath)
 
       await Promise.all([
-        this.root.updatePuttable(Branch.Public, this.root.publicTree),
-        this.root.updatePuttable(Branch.Pretty, this.root.prettyTree)
+        this.root.updatePuttable(RootBranch.Public, this.root.publicTree),
+        this.root.updatePuttable(RootBranch.Pretty, this.root.prettyTree)
       ])
 
-    } else if (head === Branch.Private) {
+    } else if (head === RootBranch.Private) {
       const [ nodePath, node ] = this.root.findPrivateNode(path)
 
       if (!node) {
@@ -745,12 +745,12 @@ export class FileSystem implements API {
 
       await handlers.private(node, parts.slice(Path.unwrap(nodePath).length))
       await node.put()
-      await this.root.updatePuttable(Branch.Private, this.root.mmpt)
+      await this.root.updatePuttable(RootBranch.Private, this.root.mmpt)
 
       const cid = await this.root.mmpt.put()
       await this.root.addPrivateLogEntry(this.dependencies.depot, cid)
 
-    } else if (head === Branch.Pretty) {
+    } else if (head === RootBranch.Pretty) {
       throw new Error("The pretty path is read only")
 
     } else {
@@ -760,7 +760,7 @@ export class FileSystem implements API {
 
   /** @internal */
   async runOnNode<A>(
-    path: DistinctivePath<Branched>,
+    path: DistinctivePath<Partitioned<Partition>>,
     handlers: {
       public(root: UnixTree, relPath: Path.Segments): Promise<A>
       private(node: Tree | File, relPath: Path.Segments): Promise<A>
@@ -772,10 +772,10 @@ export class FileSystem implements API {
 
     await this.checkMutationPermissionAndAddProof(path, false)
 
-    if (head === Branch.Public) {
+    if (head === RootBranch.Public) {
       return await handlers.public(this.root.publicTree, relPath)
 
-    } else if (head === Branch.Private) {
+    } else if (head === RootBranch.Private) {
       const [ nodePath, node ] = this.root.findPrivateNode(path)
 
       if (!node) {
@@ -784,7 +784,7 @@ export class FileSystem implements API {
 
       return await handlers.private(node, parts.slice(Path.unwrap(nodePath).length))
 
-    } else if (head === Branch.Pretty) {
+    } else if (head === RootBranch.Pretty) {
       return await handlers.public(this.root.prettyTree, relPath)
 
     } else {

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -650,7 +650,7 @@ export class FileSystem implements API {
    */
   async sharePrivate(paths: Path.Distinctive<Path.PartitionedNonEmpty<Path.Private>>[], { sharedBy, shareWith }: { sharedBy?: SharedBy; shareWith: string | string[] }): Promise<ShareDetails> {
     const verifiedPaths = paths.filter(path => {
-      return Path.isRootBranch(Path.RootBranch.Private, path)
+      return Path.isOnRootBranch(Path.RootBranch.Private, path)
     })
 
     // Our username

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -246,7 +246,7 @@ export class FileSystem implements API {
   // -----------------------
 
   async write(
-    path: Path.Distinctive<PartitionedNonEmpty<Partition>>,
+    path: Path.Distinctive<Partitioned<Partition>>,
     content: Uint8Array | SoftLink | SoftLink[] | Record<string, SoftLink>,
     options: MutationOptions = {}
   ): Promise<this> {

--- a/src/fs/root/tree.ts
+++ b/src/fs/root/tree.ts
@@ -271,7 +271,7 @@ export default class RootTree implements Puttable {
   // PRIVATE TREES
   // -------------
 
-  findPrivateNode(path: DistinctivePath): [ DistinctivePath, PrivateNode | null ] {
+  findPrivateNode(path: DistinctivePath<Path.Segments>): [ DistinctivePath<Path.Segments>, PrivateNode | null ] {
     return findPrivateNode(this.privateNodes, path)
   }
 
@@ -432,7 +432,7 @@ export default class RootTree implements Puttable {
 // ㊙️
 
 
-type PathKey = { path: DistinctivePath; key: Uint8Array }
+type PathKey = { path: DistinctivePath<Path.Segments>; key: Uint8Array }
 
 
 async function findBareNameFilter(
@@ -440,7 +440,7 @@ async function findBareNameFilter(
   storage: Storage.Implementation,
   accountDID: string,
   map: Record<string, PrivateNode>,
-  path: DistinctivePath
+  path: DistinctivePath<Path.Segments>
 ): Promise<Maybe<BareNameFilter>> {
   const bareNameFilterId = await Identifiers.bareNameFilter({ accountDID, crypto, path })
   const bareNameFilter: Maybe<BareNameFilter> = await storage.getItem(bareNameFilterId)
@@ -466,8 +466,8 @@ async function findBareNameFilter(
 
 function findPrivateNode(
   map: Record<string, PrivateNode>,
-  path: DistinctivePath
-): [ DistinctivePath, PrivateNode | null ] {
+  path: DistinctivePath<Path.Segments>
+): [ DistinctivePath<Path.Segments>, PrivateNode | null ] {
   const t = map[ Path.toPosix(path) ]
   if (t) return [ path, t ]
 
@@ -523,7 +523,7 @@ async function permissionKeys(
 ): Promise<PathKey[]> {
   return permissionPaths(permissions).reduce(async (
     acc: Promise<PathKey[]>,
-    path: DistinctivePath
+    path: DistinctivePath<Path.Segments>
   ): Promise<PathKey[]> => {
     if (Path.isBranch(Path.Branch.Public, path)) return acc
 

--- a/src/fs/share.ts
+++ b/src/fs/share.ts
@@ -27,7 +27,7 @@ import RootTree from "./root/tree.js"
 // CONSTANTS
 
 
-export const EXCHANGE_PATH: DirectoryPath = Path.directory(
+export const EXCHANGE_PATH: Path.Directory<Path.Branched> = Path.directory(
   Path.Branch.Public,
   ".well-known",
   "exchange"

--- a/src/fs/share.ts
+++ b/src/fs/share.ts
@@ -12,7 +12,7 @@ import * as Protocol from "./protocol/index.js"
 import * as EntryIndex from "./protocol/shared/entry-index.js"
 import * as ShareKey from "./protocol/shared/key.js"
 
-import { Branch, DirectoryPath } from "../path/index.js"
+import { RootBranch } from "../path/index.js"
 import { SharedBy, ShareDetails } from "./types.js"
 import { SymmAlg } from "../components/crypto/implementation.js"
 import { decodeCID, encodeCID } from "../common/cid.js"
@@ -27,8 +27,8 @@ import RootTree from "./root/tree.js"
 // CONSTANTS
 
 
-export const EXCHANGE_PATH: Path.Directory<Path.Branched> = Path.directory(
-  Path.Branch.Public,
+export const EXCHANGE_PATH: Path.Directory<Path.PartitionedNonEmpty<Path.Public>> = Path.directory(
+  "public",
   ".well-known",
   "exchange"
 )
@@ -145,11 +145,11 @@ export async function listExchangeDIDs(
   if (!root) throw new Error("This person doesn't have a filesystem yet.")
 
   const rootLinks = await Protocol.basic.getSimpleLinks(depot, root)
-  const prettyTreeCid = rootLinks[ Branch.Pretty ]?.cid || null
+  const prettyTreeCid = rootLinks[ RootBranch.Pretty ]?.cid || null
   if (!prettyTreeCid) throw new Error("This person's filesystem doesn't have a pretty tree.")
 
   const tree = await BareTree.fromCID(depot, decodeCID(prettyTreeCid))
-  const exchangePath = Path.unwrap(Path.removeBranch(EXCHANGE_PATH))
+  const exchangePath = Path.unwrap(Path.removePartition(EXCHANGE_PATH))
   const exchangeTree = await tree.get(exchangePath)
 
   return exchangeTree && exchangeTree instanceof BareTree

--- a/src/fs/types.ts
+++ b/src/fs/types.ts
@@ -4,7 +4,7 @@ import * as Path from "../path/index.js"
 
 import { Maybe } from "../common/index.js"
 import { PutResult } from "../components/depot/implementation.js"
-import { DirectoryPath, DistinctivePath, FilePath, Branched, Segments } from "../path/index.js"
+import { DirectoryPath, DistinctivePath, FilePath, Partitioned, PartitionedNonEmpty, Partition } from "../path/index.js"
 import { Ucan } from "../ucan/types.js"
 
 
@@ -23,32 +23,32 @@ export interface Properties {
 }
 
 export interface Posix {
-  exists(path: DistinctivePath<Branched>): Promise<boolean>
-  get(path: DistinctivePath<Branched>): Promise<PuttableUnixTree | File | null>
-  mv(from: DistinctivePath<Branched>, to: DistinctivePath<Branched>): Promise<this>
-  rm(path: DistinctivePath<Branched>): Promise<this>
+  exists(path: DistinctivePath<PartitionedNonEmpty<Partition>>): Promise<boolean>
+  get(path: DistinctivePath<Partitioned<Partition>>): Promise<PuttableUnixTree | File | null>
+  mv(from: DistinctivePath<PartitionedNonEmpty<Partition>>, to: DistinctivePath<PartitionedNonEmpty<Partition>>): Promise<this>
+  rm(path: DistinctivePath<PartitionedNonEmpty<Partition>>): Promise<this>
 
   resolveSymlink(link: SoftLink): Promise<File | Tree | null>
-  symlink(args: { at: DirectoryPath<Branched>; referringTo: DistinctivePath<Branched>; name: string }): Promise<this>
+  symlink(args: { at: DirectoryPath<PartitionedNonEmpty<Partition>>; referringTo: DistinctivePath<PartitionedNonEmpty<Partition>>; name: string }): Promise<this>
 
   // Directories
-  ls(path: DirectoryPath<Branched>): Promise<Links>
-  mkdir(path: DirectoryPath<Branched>, options?: MutationOptions): Promise<this>
+  ls(path: DirectoryPath<Partitioned<Partition>>): Promise<Links>
+  mkdir(path: DirectoryPath<PartitionedNonEmpty<Partition>>, options?: MutationOptions): Promise<this>
 
   // Files
   write(
-    path: DistinctivePath<Branched>,
+    path: DistinctivePath<PartitionedNonEmpty<Partition>>,
     content: Uint8Array | SoftLink | SoftLink[] | Record<string, SoftLink>,
     options?: MutationOptions
   ): Promise<this>
 
-  read(path: FilePath<Branched>): Promise<Uint8Array | null>
+  read(path: FilePath<PartitionedNonEmpty<Partition>>): Promise<Uint8Array | null>
 }
 
 export interface Sharing {
   acceptShare({ shareId, sharedBy }: { shareId: string; sharedBy: string }): Promise<this>
   loadShare({ shareId, sharedBy }: { shareId: string; sharedBy: string }): Promise<UnixTree>
-  sharePrivate(paths: DistinctivePath<Path.Private>[], { sharedBy, shareWith }: { sharedBy?: SharedBy; shareWith: string | string[] }): Promise<ShareDetails>
+  sharePrivate(paths: DistinctivePath<Path.PartitionedNonEmpty<Path.Private>>[], { sharedBy, shareWith }: { sharedBy?: SharedBy; shareWith: string | string[] }): Promise<ShareDetails>
 }
 
 

--- a/src/fs/types.ts
+++ b/src/fs/types.ts
@@ -1,8 +1,10 @@
 import type { CID } from "multiformats/cid"
 
+import * as Path from "../path/index.js"
+
 import { Maybe } from "../common/index.js"
 import { PutResult } from "../components/depot/implementation.js"
-import { DirectoryPath, DistinctivePath, FilePath, Path } from "../path/index.js"
+import { DirectoryPath, DistinctivePath, FilePath, Branched, Segments } from "../path/index.js"
 import { Ucan } from "../ucan/types.js"
 
 
@@ -21,32 +23,32 @@ export interface Properties {
 }
 
 export interface Posix {
-  exists(path: DistinctivePath): Promise<boolean>
-  get(path: DistinctivePath): Promise<PuttableUnixTree | File | null>
-  mv(from: DistinctivePath, to: DistinctivePath): Promise<this>
-  rm(path: DistinctivePath): Promise<this>
+  exists(path: DistinctivePath<Branched>): Promise<boolean>
+  get(path: DistinctivePath<Branched>): Promise<PuttableUnixTree | File | null>
+  mv(from: DistinctivePath<Branched>, to: DistinctivePath<Branched>): Promise<this>
+  rm(path: DistinctivePath<Branched>): Promise<this>
 
   resolveSymlink(link: SoftLink): Promise<File | Tree | null>
-  symlink(args: { at: DirectoryPath; referringTo: DistinctivePath; name: string }): Promise<this>
+  symlink(args: { at: DirectoryPath<Branched>; referringTo: DistinctivePath<Branched>; name: string }): Promise<this>
 
   // Directories
-  ls(path: DirectoryPath): Promise<Links>
-  mkdir(path: DirectoryPath, options?: MutationOptions): Promise<this>
+  ls(path: DirectoryPath<Branched>): Promise<Links>
+  mkdir(path: DirectoryPath<Branched>, options?: MutationOptions): Promise<this>
 
   // Files
   write(
-    path: DistinctivePath,
+    path: DistinctivePath<Branched>,
     content: Uint8Array | SoftLink | SoftLink[] | Record<string, SoftLink>,
     options?: MutationOptions
   ): Promise<this>
 
-  read(path: FilePath): Promise<Uint8Array | null>
+  read(path: FilePath<Branched>): Promise<Uint8Array | null>
 }
 
 export interface Sharing {
   acceptShare({ shareId, sharedBy }: { shareId: string; sharedBy: string }): Promise<this>
   loadShare({ shareId, sharedBy }: { shareId: string; sharedBy: string }): Promise<UnixTree>
-  sharePrivate(paths: DistinctivePath[], { sharedBy, shareWith }: { sharedBy?: SharedBy; shareWith: string | string[] }): Promise<ShareDetails>
+  sharePrivate(paths: DistinctivePath<Path.Private>[], { sharedBy, shareWith }: { sharedBy?: SharedBy; shareWith: string | string[] }): Promise<ShareDetails>
 }
 
 
@@ -131,28 +133,28 @@ export type MutationOptions = {
 export interface UnixTree {
   readOnly: boolean
 
-  ls(path: Path): Promise<Links>
-  mkdir(path: Path): Promise<this>
-  cat(path: Path): Promise<Uint8Array>
-  add(path: Path, content: Uint8Array): Promise<this>
-  rm(path: Path): Promise<this>
-  mv(from: Path, to: Path): Promise<this>
-  get(path: Path): Promise<PuttableUnixTree | File | null>
-  exists(path: Path): Promise<boolean>
+  ls(path: Path.Segments): Promise<Links>
+  mkdir(path: Path.Segments): Promise<this>
+  cat(path: Path.Segments): Promise<Uint8Array>
+  add(path: Path.Segments, content: Uint8Array): Promise<this>
+  rm(path: Path.Segments): Promise<this>
+  mv(from: Path.Segments, to: Path.Segments): Promise<this>
+  get(path: Path.Segments): Promise<PuttableUnixTree | File | null>
+  exists(path: Path.Segments): Promise<boolean>
 }
 
 export interface Tree extends UnixTree, Puttable {
   createChildTree(name: string, onUpdate: Maybe<UpdateCallback>): Promise<Tree>
   createOrUpdateChildFile(content: Uint8Array, name: string, onUpdate: Maybe<UpdateCallback>): Promise<File>
 
-  mkdirRecurse(path: Path, onUpdate: Maybe<UpdateCallback>): Promise<this>
-  addRecurse(path: Path, content: Uint8Array, onUpdate: Maybe<UpdateCallback>): Promise<this>
-  rmRecurse(path: Path, onUpdate: Maybe<UpdateCallback>): Promise<this>
+  mkdirRecurse(path: Path.Segments, onUpdate: Maybe<UpdateCallback>): Promise<this>
+  addRecurse(path: Path.Segments, content: Uint8Array, onUpdate: Maybe<UpdateCallback>): Promise<this>
+  rmRecurse(path: Path.Segments, onUpdate: Maybe<UpdateCallback>): Promise<this>
 
-  updateChild(child: Tree | File, path: Path): Promise<this>
+  updateChild(child: Tree | File, path: Path.Segments): Promise<this>
   updateDirectChild(child: Tree | File, name: string, onUpdate: Maybe<UpdateCallback>): Promise<this>
   removeDirectChild(name: string): this
-  get(path: Path): Promise<Tree | File | null>
+  get(path: Path.Segments): Promise<Tree | File | null>
   getDirectChild(name: string): Promise<Tree | File | null>
   getOrCreateDirectChild(name: string, onUpdate: Maybe<UpdateCallback>): Promise<Tree | File>
 

--- a/src/fs/v1/PrivateTree.ts
+++ b/src/fs/v1/PrivateTree.ts
@@ -14,7 +14,7 @@ import PrivateHistory from "./PrivateHistory.js"
 import { DEFAULT_AES_ALG } from "../protocol/basic.js"
 import { Links, SoftLink, UpdateCallback } from "../types.js"
 import { DecryptedNode, PrivateSkeletonInfo, PrivateTreeInfo, PrivateAddResult, PrivateLink, PrivateSkeleton } from "../protocol/private/types.js"
-import { Path } from "../../path/index.js"
+import { Segments as Path } from "../../path/index.js"
 import { PrivateName, BareNameFilter } from "../protocol/private/namefilter.js"
 import { decodeCID, isObject, hasProp, mapObj, Maybe, removeKeyFromObj, encodeCID } from "../../common/index.js"
 

--- a/src/fs/v1/PublicTree.ts
+++ b/src/fs/v1/PublicTree.ts
@@ -198,7 +198,7 @@ export class PublicTree extends BaseTree {
     return child
   }
 
-  async get(path: Path.Path): Promise<Child | null> {
+  async get(path: Path.Segments): Promise<Child | null> {
     if (path.length < 1) return this
 
     const res = await this.getRecurse(this.header.skeleton, path as NonEmptyPath)
@@ -309,7 +309,7 @@ export class PublicTree extends BaseTree {
     return this
   }
 
-  insertSoftLink({ name, path, username }: { name: string; path: DistinctivePath; username: string }): this {
+  insertSoftLink({ name, path, username }: { name: string; path: DistinctivePath<Path.Segments>; username: string }): this {
     const softLink = {
       ipns: this.reference.dataRoot.domain(username) + `/public/${Path.toPosix(path)}`,
       name

--- a/src/fs/v1/PublicTree.ts
+++ b/src/fs/v1/PublicTree.ts
@@ -262,8 +262,8 @@ export class PublicTree extends BaseTree {
     const [ domain, ...pieces ] = link.ipns.split("/")
     const path = Path.fromPosix(pieces.join("/"))
     const isPublic =
-      Path.isRootBranch(Path.RootBranch.Public, path) ||
-      Path.isRootBranch(Path.RootBranch.Pretty, path)
+      Path.isOnRootBranch(Path.RootBranch.Public, path) ||
+      Path.isOnRootBranch(Path.RootBranch.Pretty, path)
 
     if (!isPublic) throw new Error("Mixing public and private soft links is not supported yet.")
 

--- a/src/fs/v1/PublicTree.ts
+++ b/src/fs/v1/PublicTree.ts
@@ -262,8 +262,8 @@ export class PublicTree extends BaseTree {
     const [ domain, ...pieces ] = link.ipns.split("/")
     const path = Path.fromPosix(pieces.join("/"))
     const isPublic =
-      Path.isBranch(Path.Branch.Public, path) ||
-      Path.isBranch(Path.Branch.Pretty, path)
+      Path.isRootBranch(Path.RootBranch.Public, path) ||
+      Path.isRootBranch(Path.RootBranch.Pretty, path)
 
     if (!isPublic) throw new Error("Mixing public and private soft links is not supported yet.")
 
@@ -271,7 +271,7 @@ export class PublicTree extends BaseTree {
     if (!rootCid) throw new Error(`Failed to resolve the soft link: ${link.ipns} - Could not resolve DNSLink`)
 
     const publicCid = (await Protocol.basic.getSimpleLinks(depot, decodeCID(rootCid))).public.cid
-    const publicPath = Path.removeBranch(path)
+    const publicPath = Path.removePartition(path)
     const publicTree = await PublicTree.fromCID(depot, reference, decodeCID(publicCid))
 
     const item = await publicTree.get(Path.unwrap(publicPath))

--- a/src/fs/v3/PublicRootWasm.ts
+++ b/src/fs/v3/PublicRootWasm.ts
@@ -5,7 +5,7 @@ import * as Depot from "../../components/depot/implementation.js"
 import * as Manners from "../../components/manners/implementation.js"
 
 import { WASM_WNFS_VERSION } from "../../common/version.js"
-import { Path } from "../../path/index.js"
+import { Segments as Path } from "../../path/index.js"
 
 import { UnixTree, Puttable, File, Links, PuttableUnixTree } from "../types.js"
 import { BlockStore, DepotBlockStore } from "./DepotBlockStore.js"

--- a/src/path/index.node.test.ts
+++ b/src/path/index.node.test.ts
@@ -108,7 +108,7 @@ describe("the path helpers", () => {
       creator: "Fission"
     }
 
-    const root: DirectoryPath = Path.appData(
+    const root: DirectoryPath<Path.Branched> = Path.appData(
       appInfo
     )
 
@@ -118,7 +118,7 @@ describe("the path helpers", () => {
       { directory: [ Path.Branch.Private, "Apps", appInfo.creator, appInfo.name ] }
     )
 
-    const dir: DirectoryPath = Path.appData(
+    const dir: DirectoryPath<Path.Branched> = Path.appData(
       appInfo,
       Path.directory("a")
     )
@@ -129,7 +129,7 @@ describe("the path helpers", () => {
       { directory: [ Path.Branch.Private, "Apps", appInfo.creator, appInfo.name, "a" ] }
     )
 
-    const file: FilePath = Path.appData(
+    const file: FilePath<Path.Branched> = Path.appData(
       appInfo,
       Path.file("a")
     )
@@ -143,7 +143,7 @@ describe("the path helpers", () => {
 
 
   it("can be combined", () => {
-    const dir: DirectoryPath = Path.combine(
+    const dir: DirectoryPath<Path.Segments> = Path.combine(
       Path.directory("a"),
       Path.directory("b")
     )
@@ -154,7 +154,7 @@ describe("the path helpers", () => {
       { directory: [ "a", "b" ] }
     )
 
-    const file: FilePath = Path.combine(
+    const file: FilePath<Path.Segments> = Path.combine(
       Path.directory("a"),
       Path.file("b")
     )

--- a/src/path/index.node.test.ts
+++ b/src/path/index.node.test.ts
@@ -1,7 +1,7 @@
 import expect from "expect"
 import * as fc from "fast-check"
 import * as Path from "./index.js"
-import { DirectoryPath, FilePath } from "./index.js"
+import { DirectoryPath, FilePath, RootBranch } from "./index.js"
 
 
 describe("the path helpers", () => {
@@ -23,6 +23,11 @@ describe("the path helpers", () => {
     expect(() =>
       Path.directory("/")
     ).toThrow()
+
+    // Type testing
+    const a: Path.Directory<Path.Partitioned<Path.Private>> = Path.directory("private")
+    const b: Path.Directory<Path.PartitionedNonEmpty<Path.Public>> = Path.directory("public", "a")
+    const c: Path.Directory<Path.Segments> = Path.directory("private", "a", "b")
   })
 
   it("creates file paths", () => {
@@ -37,6 +42,10 @@ describe("the path helpers", () => {
     expect(() =>
       Path.file("/")
     ).toThrow()
+
+    // Type testing
+    const a: Path.File<Path.PartitionedNonEmpty<Path.Private>> = Path.file("private", "a")
+    const b: Path.File<Path.Segments> = Path.file("private", "a", "b")
   })
 
 
@@ -108,17 +117,17 @@ describe("the path helpers", () => {
       creator: "Fission"
     }
 
-    const root: DirectoryPath<Path.Branched> = Path.appData(
+    const root: DirectoryPath<Path.PartitionedNonEmpty<Path.Private>> = Path.appData(
       appInfo
     )
 
     expect(
       root
     ).toEqual(
-      { directory: [ Path.Branch.Private, "Apps", appInfo.creator, appInfo.name ] }
+      { directory: [ RootBranch.Private, "Apps", appInfo.creator, appInfo.name ] }
     )
 
-    const dir: DirectoryPath<Path.Branched> = Path.appData(
+    const dir: DirectoryPath<Path.PartitionedNonEmpty<Path.Private>> = Path.appData(
       appInfo,
       Path.directory("a")
     )
@@ -126,10 +135,10 @@ describe("the path helpers", () => {
     expect(
       dir
     ).toEqual(
-      { directory: [ Path.Branch.Private, "Apps", appInfo.creator, appInfo.name, "a" ] }
+      { directory: [ RootBranch.Private, "Apps", appInfo.creator, appInfo.name, "a" ] }
     )
 
-    const file: FilePath<Path.Branched> = Path.appData(
+    const file: FilePath<Path.PartitionedNonEmpty<Path.Private>> = Path.appData(
       appInfo,
       Path.file("a")
     )
@@ -137,7 +146,7 @@ describe("the path helpers", () => {
     expect(
       file
     ).toEqual(
-      { file: [ Path.Branch.Private, "Apps", appInfo.creator, appInfo.name, "a" ] }
+      { file: [ RootBranch.Private, "Apps", appInfo.creator, appInfo.name, "a" ] }
     )
   })
 
@@ -164,21 +173,52 @@ describe("the path helpers", () => {
     ).toEqual(
       { file: [ "a", "b" ] }
     )
+
+    // Type testing
+    const a: DirectoryPath<Path.PartitionedNonEmpty<Path.Private>> = Path.combine(
+      Path.directory("private"),
+      Path.directory("a"),
+    )
+
+    const aa: FilePath<Path.Partitioned<Path.Public>> = Path.combine(
+      Path.directory("public"),
+      Path.file("a"),
+    )
+
+    const b: DirectoryPath<Path.Partitioned<Path.Private>> = Path.combine(
+      Path.directory("private"),
+      Path.directory(),
+    )
+
+    const bb: FilePath<Path.Partitioned<Path.Public>> = Path.combine(
+      Path.directory("public"),
+      Path.file(),
+    )
+
+    const c: DirectoryPath<Path.PartitionedNonEmpty<Path.Private>> = Path.combine(
+      Path.directory("private"),
+      Path.directory("a"),
+    )
+
+    const cc: FilePath<Path.PartitionedNonEmpty<Path.Public>> = Path.combine(
+      Path.directory("public"),
+      Path.file("a"),
+    )
   })
 
 
-  it("supports isBranch", () => {
+  it("supports isRootBranch", () => {
     expect(
-      Path.isBranch(
-        Path.Branch.Private,
-        Path.directory(Path.Branch.Private, "a")
+      Path.isRootBranch(
+        RootBranch.Private,
+        Path.directory(RootBranch.Private, "a")
       )
     ).toBe(true)
 
     expect(
-      Path.isBranch(
-        Path.Branch.Public,
-        Path.directory(Path.Branch.Private, "a")
+      Path.isRootBranch(
+        RootBranch.Public,
+        Path.directory(RootBranch.Private, "a")
       )
     ).toBe(false)
   })
@@ -187,7 +227,7 @@ describe("the path helpers", () => {
   it("supports isDirectory", () => {
     expect(
       Path.isDirectory(
-        Path.directory(Path.Branch.Private)
+        Path.directory(RootBranch.Private)
       )
     ).toBe(true)
 
@@ -208,7 +248,7 @@ describe("the path helpers", () => {
 
     expect(
       Path.isFile(
-        Path.directory(Path.Branch.Private)
+        Path.directory(RootBranch.Private)
       )
     ).toBe(false)
   })
@@ -229,24 +269,24 @@ describe("the path helpers", () => {
 
     expect(
       Path.isRootDirectory(
-        Path.directory(Path.Branch.Private)
+        Path.directory(RootBranch.Private)
       )
     ).toBe(false)
   })
 
 
-  it("supports isSameBranch", () => {
+  it("supports isSamePartition", () => {
     expect(
-      Path.isSameBranch(
-        Path.directory(Path.Branch.Private),
-        Path.directory(Path.Branch.Private)
+      Path.isSamePartition(
+        Path.directory(RootBranch.Private),
+        Path.directory(RootBranch.Private)
       )
     ).toBe(true)
 
     expect(
-      Path.isSameBranch(
-        Path.directory(Path.Branch.Private),
-        Path.directory(Path.Branch.Public)
+      Path.isSamePartition(
+        Path.directory(RootBranch.Private),
+        Path.directory(RootBranch.Public)
       )
     ).toBe(false)
   })
@@ -346,9 +386,9 @@ describe("the path helpers", () => {
   })
 
 
-  it("supports removeBranch", () => {
+  it("supports removePartition", () => {
     expect(
-      Path.removeBranch(
+      Path.removePartition(
         Path.directory("foo")
       )
     ).toEqual(
@@ -356,7 +396,7 @@ describe("the path helpers", () => {
     )
 
     expect(
-      Path.removeBranch(
+      Path.removePartition(
         Path.directory("foo", "bar")
       )
     ).toEqual(

--- a/src/path/index.node.test.ts
+++ b/src/path/index.node.test.ts
@@ -207,16 +207,16 @@ describe("the path helpers", () => {
   })
 
 
-  it("supports isRootBranch", () => {
+  it("supports isOnRootBranch", () => {
     expect(
-      Path.isRootBranch(
+      Path.isOnRootBranch(
         RootBranch.Private,
         Path.directory(RootBranch.Private, "a")
       )
     ).toBe(true)
 
     expect(
-      Path.isRootBranch(
+      Path.isOnRootBranch(
         RootBranch.Public,
         Path.directory(RootBranch.Private, "a")
       )

--- a/src/path/index.ts
+++ b/src/path/index.ts
@@ -203,7 +203,7 @@ export function isPartition(partition: Partition, path: DistinctivePath<Segments
 /**
  * Is this `DistinctivePath` on the given `RootBranch`?
  */
-export function isRootBranch(rootBranch: RootBranch, path: DistinctivePath<Segments>): boolean {
+export function isOnRootBranch(rootBranch: RootBranch, path: DistinctivePath<Segments>): boolean {
   return unwrap(path)[ 0 ] === rootBranch
 }
 

--- a/src/path/index.ts
+++ b/src/path/index.ts
@@ -17,15 +17,34 @@ export enum Kind {
   File = "file"
 }
 
-export type Path = string[]
+export type Segments = string[]
+export type Branched = [ Branch, ...Segments ]
 
-export type DirectoryPath = { directory: Path }
-export type FilePath = { file: Path }
+export type Private = [ Branch.Private, ...Segments ]
+export type Public = [ Branch.Public, ...Segments ]
+
+export type DirectoryPath<P> = { directory: P }
+export type FilePath<P> = { file: P }
 
 /**
- * The primarily used type for paths.
+ * A file or directory path.
  */
-export type DistinctivePath = DirectoryPath | FilePath
+export type DistinctivePath<P> = DirectoryPath<P> | FilePath<P>
+
+/**
+ * Alias for `DirectoryPath`
+ */
+export type Directory<P> = DirectoryPath<P>
+
+/**
+ * Alias for `FilePath`
+ */
+export type File<P> = FilePath<P>
+
+/**
+ * Alias for `DistinctivePath`
+ */
+export type Distinctive<P> = DistinctivePath<P>
 
 
 
@@ -35,7 +54,9 @@ export type DistinctivePath = DirectoryPath | FilePath
 /**
  * Utility function to create a `DirectoryPath`
  */
-export function directory(...args: Path): DirectoryPath {
+export function directory(...args: Branched): DirectoryPath<Branched>
+export function directory(...args: Segments): DirectoryPath<Segments>
+export function directory(...args: Segments | Branched): DirectoryPath<Segments | Branched> {
   if (args.some(p => p.includes("/"))) {
     throw new Error("Forward slashes `/` are not allowed")
   }
@@ -45,7 +66,9 @@ export function directory(...args: Path): DirectoryPath {
 /**
  * Utility function to create a `FilePath`
  */
-export function file(...args: Path): FilePath {
+export function file(...args: Branched): FilePath<Branched>
+export function file(...args: Segments): FilePath<Segments>
+export function file(...args: Segments | Branched): FilePath<Segments | Branched> {
   if (args.some(p => p.includes("/"))) {
     throw new Error("Forward slashes `/` are not allowed")
   }
@@ -55,21 +78,19 @@ export function file(...args: Path): FilePath {
 /**
  * Utility function to create a root `DirectoryPath`
  */
-export function root(): DirectoryPath {
+export function root(): DirectoryPath<Segments> {
   return { directory: [] }
 }
 
 /**
  * Utility function create an app data path.
  */
-export function appData(app: AppInfo): DirectoryPath
-export function appData(app: AppInfo, suffix: FilePath): FilePath
-export function appData(app: AppInfo, suffix: DirectoryPath): DirectoryPath
-export function appData(app: AppInfo, suffix: DistinctivePath): DistinctivePath
-export function appData(app: AppInfo, suffix?: DistinctivePath): DistinctivePath {
-  const parent = directory(Branch.Private, "Apps", app.creator, app.name)
-  if (suffix) return combine(parent, suffix)
-  return parent
+export function appData(app: AppInfo): DirectoryPath<Branched>
+export function appData(app: AppInfo, suffix: FilePath<Segments>): FilePath<Branched>
+export function appData(app: AppInfo, suffix: DirectoryPath<Segments>): DirectoryPath<Branched>
+export function appData(app: AppInfo, suffix: DistinctivePath<Segments>): DistinctivePath<Branched>
+export function appData(app: AppInfo, suffix?: DistinctivePath<Segments>): DistinctivePath<Branched> {
+  return directory(Branch.Private, "Apps", app.creator, app.name, ...(suffix ? unwrap(suffix) : []))
 }
 
 
@@ -85,7 +106,7 @@ export function appData(app: AppInfo, suffix?: DistinctivePath): DistinctivePath
  *
  * Leading forward slashes are removed too, so you can pass absolute paths.
  */
-export function fromPosix(path: string): DistinctivePath {
+export function fromPosix(path: string): DistinctivePath<Segments> {
   const split = path.replace(/^\/+/, "").split("/")
   if (path.endsWith("/")) return { directory: split.slice(0, -1) }
   else if (path === "") return root()
@@ -99,7 +120,7 @@ export function fromPosix(path: string): DistinctivePath {
  * files will have the format `path/to/file`.
  */
 export function toPosix(
-  path: DistinctivePath,
+  path: DistinctivePath<Segments>,
   { absolute }: { absolute: boolean } = { absolute: false }
 ): string {
   const prefix = absolute ? "/" : ""
@@ -116,52 +137,55 @@ export function toPosix(
 /**
  * Combine two `DistinctivePath`s.
  */
-export function combine(a: DirectoryPath, b: FilePath): FilePath
-export function combine(a: DirectoryPath, b: DirectoryPath): DirectoryPath
-export function combine(a: DirectoryPath, b: DistinctivePath): DistinctivePath
-export function combine(a: DirectoryPath, b: DistinctivePath): DistinctivePath {
+export function combine(a: DirectoryPath<Branched>, b: FilePath<Segments>): FilePath<Branched>
+export function combine(a: DirectoryPath<Segments>, b: FilePath<Segments>): FilePath<Segments>
+export function combine(a: DirectoryPath<Branched>, b: DirectoryPath<Segments>): DirectoryPath<Branched>
+export function combine(a: DirectoryPath<Segments>, b: DirectoryPath<Segments>): DirectoryPath<Segments>
+export function combine(a: DirectoryPath<Branched>, b: DistinctivePath<Segments>): DistinctivePath<Branched>
+export function combine(a: DirectoryPath<Segments>, b: DistinctivePath<Segments>): DistinctivePath<Segments>
+export function combine(a: DirectoryPath<Segments>, b: DistinctivePath<Segments>): DistinctivePath<Segments> {
   return map(p => unwrap(a).concat(p), b)
 }
 
 /**
  * Is this `DistinctivePath` of the given `Branch`?
  */
-export function isBranch(branch: Branch, path: DistinctivePath): boolean {
+export function isBranch(branch: Branch, path: DistinctivePath<Segments>): boolean {
   return unwrap(path)[ 0 ] === branch
 }
 
 /**
  * Is this `DistinctivePath` a directory?
  */
-export function isDirectory(path: DistinctivePath): path is DirectoryPath {
-  return !!(path as DirectoryPath).directory
+export function isDirectory<P>(path: DistinctivePath<P>): path is DirectoryPath<P> {
+  return !!(path as DirectoryPath<P>).directory
 }
 
 /**
  * Is this `DistinctivePath` a file?
  */
-export function isFile(path: DistinctivePath): path is FilePath {
-  return !!(path as FilePath).file
+export function isFile<P>(path: DistinctivePath<P>): path is FilePath<P> {
+  return !!(path as FilePath<P>).file
 }
 
 /**
  * Is this `DirectoryPath` a root directory?
  */
-export function isRootDirectory(path: DirectoryPath): boolean {
+export function isRootDirectory(path: DirectoryPath<Segments>): boolean {
   return path.directory.length === 0
 }
 
 /**
  * Check if two `DistinctivePath` have the same `Branch`.
  */
-export function isSameBranch(a: DistinctivePath, b: DistinctivePath): boolean {
+export function isSameBranch(a: DistinctivePath<Segments>, b: DistinctivePath<Segments>): boolean {
   return unwrap(a)[ 0 ] === unwrap(b)[ 0 ]
 }
 
 /**
  * Check if two `DistinctivePath` are of the same kind.
  */
-export function isSameKind(a: DistinctivePath, b: DistinctivePath): boolean {
+export function isSameKind(a: DistinctivePath<Segments>, b: DistinctivePath<Segments>): boolean {
   if (isDirectory(a) && isDirectory(b)) return true
   else if (isFile(a) && isFile(b)) return true
   else return false
@@ -170,7 +194,7 @@ export function isSameKind(a: DistinctivePath, b: DistinctivePath): boolean {
 /**
  * What `Kind` of path are we dealing with?
  */
-export function kind(path: DistinctivePath): Kind {
+export function kind(path: DistinctivePath<Segments>): Kind {
   if (isDirectory(path)) return Kind.Directory
   return Kind.File
 }
@@ -178,7 +202,7 @@ export function kind(path: DistinctivePath): Kind {
 /**
  * Map a `DistinctivePath`.
  */
-export function map(fn: (p: Path) => Path, path: DistinctivePath): DistinctivePath {
+export function map<P>(fn: (p: P) => P, path: DistinctivePath<P>): DistinctivePath<P> {
   if (isDirectory(path)) return { directory: fn(path.directory) }
   else if (isFile(path)) return { file: fn(path.file) }
   return path
@@ -187,8 +211,8 @@ export function map(fn: (p: Path) => Path, path: DistinctivePath): DistinctivePa
 /**
  * Get the parent directory of a `DistinctivePath`.
  */
-export function parent(path: DistinctivePath): Maybe<DirectoryPath> {
-  return isDirectory(path) && isRootDirectory(path as DirectoryPath)
+export function parent(path: DistinctivePath<Segments>): Maybe<DirectoryPath<Segments>> {
+  return isDirectory(path) && isRootDirectory(path as DirectoryPath<Segments>)
     ? null
     : directory(...unwrap(path).slice(0, -1))
 }
@@ -196,7 +220,7 @@ export function parent(path: DistinctivePath): Maybe<DirectoryPath> {
 /**
  * Remove the `Branch` of a `DistinctivePath` (ie. the top-level directory)
  */
-export function removeBranch(path: DistinctivePath): DistinctivePath {
+export function removeBranch(path: DistinctivePath<Segments>): DistinctivePath<Segments> {
   return map(
     p => isDirectory(path) || p.length > 1 ? p.slice(1) : p,
     path
@@ -206,7 +230,7 @@ export function removeBranch(path: DistinctivePath): DistinctivePath {
 /**
  * Get the last part of the path.
  */
-export function terminus(path: DistinctivePath): Maybe<string> {
+export function terminus(path: DistinctivePath<Segments>): Maybe<string> {
   const u = unwrap(path)
   if (u.length < 1) return null
   return u[ u.length - 1 ]
@@ -215,14 +239,27 @@ export function terminus(path: DistinctivePath): Maybe<string> {
 /**
  * Unwrap a `DistinctivePath`.
  */
-export function unwrap(path: DistinctivePath): Path {
+export function unwrap<P>(path: DistinctivePath<P>): P {
   if (isDirectory(path)) {
     return path.directory
   } else if (isFile(path)) {
     return path.file
   }
 
-  return []
+  throw new Error("Path is neither a directory or a file")
+}
+
+/**
+ * Utility function to prefix a path with a `Branch`.
+ */
+export function withBranch(branch: Branch, path: DirectoryPath<Segments>): DirectoryPath<Branched>
+export function withBranch(branch: Branch, path: FilePath<Segments>): FilePath<Branched>
+export function withBranch(branch: Branch, path: DistinctivePath<Segments>): DistinctivePath<Branched>
+export function withBranch(branch: Branch, path: DistinctivePath<Segments>): DistinctivePath<Branched> {
+  return combine(
+    { directory: [ branch ] },
+    path
+  )
 }
 
 
@@ -233,6 +270,6 @@ export function unwrap(path: DistinctivePath): Path {
 /**
  * Render a raw `Path` to a string for logging purposes.
  */
-export function log(path: Path): string {
+export function log(path: Segments): string {
   return `[ ${path.join(", ")} ]`
 }

--- a/src/path/index.ts
+++ b/src/path/index.ts
@@ -201,7 +201,7 @@ export function isPartition(partition: Partition, path: DistinctivePath<Segments
 }
 
 /**
- * Is this `DistinctivePath` of the given `RootBranch`?
+ * Is this `DistinctivePath` on the given `RootBranch`?
  */
 export function isRootBranch(rootBranch: RootBranch, path: DistinctivePath<Segments>): boolean {
   return unwrap(path)[ 0 ] === rootBranch

--- a/src/path/index.ts
+++ b/src/path/index.ts
@@ -17,20 +17,35 @@ export enum Kind {
   File = "file"
 }
 
-/**
- * `RootBranch`es that are accessible through the file system interface.
- */
-export type Private = "private" | RootBranch.Private
-export type Public = "public" | RootBranch.Public
-export type Partition = Private | Public
-
 export type Segment = string
 export type Segments = Segment[]
 export type SegmentsNonEmpty = [ Segment, ...Segments ]
 export type Partitioned<P> = [ P, ...Segments ]
 export type PartitionedNonEmpty<P> = [ P, Segment, ...Segments ]
 
+/**
+ * Private partition
+ */
+export type Private = "private" | RootBranch.Private
+
+/**
+ * Public partition
+ */
+export type Public = "public" | RootBranch.Public
+
+/**
+ * `RootBranch`es that are accessible through the POSIX file system interface.
+ */
+export type Partition = Private | Public
+
+/**
+ * A directory path.
+ */
 export type DirectoryPath<P> = { directory: P }
+
+/**
+ * A file path.
+ */
 export type FilePath<P> = { file: P }
 
 /**

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -1,6 +1,6 @@
 import * as Path from "./path/index.js"
 import { AppInfo } from "./appInfo.js"
-import { Branched, Distinctive, Segments } from "./path/index.js"
+import { Distinctive } from "./path/index.js"
 import { Potency, Resource } from "./ucan/index.js"
 
 
@@ -61,19 +61,19 @@ export function appId(app: AppInfo): string {
  * Lists the filesystems paths for a set of `Permissions`.
  * This'll return a list of `DistinctivePath`s.
  */
-export function permissionPaths(permissions: Permissions): Distinctive<Path.Branched>[] {
-  let list = [] as Distinctive<Path.Branched>[]
+export function permissionPaths(permissions: Permissions): Distinctive<Path.Partitioned<Path.Partition>>[] {
+  let list = [] as Distinctive<Path.Partitioned<Path.Partition>>[]
 
   if (permissions.app) list.push(Path.appData(permissions.app))
   if (permissions.fs?.private) list = list.concat(
-    permissions.fs?.private.map(p => Path.withBranch(
-      Path.Branch.Private,
+    permissions.fs?.private.map(p => Path.withPartition(
+      "private",
       p
     ))
   )
   if (permissions.fs?.public) list = list.concat(
-    permissions.fs?.public.map(p => Path.withBranch(
-      Path.Branch.Public,
+    permissions.fs?.public.map(p => Path.withPartition(
+      "public",
       p
     ))
   )

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -1,6 +1,6 @@
 import * as Path from "./path/index.js"
 import { AppInfo } from "./appInfo.js"
-import { DistinctivePath } from "./path/index.js"
+import { Branched, Distinctive, Segments } from "./path/index.js"
 import { Potency, Resource } from "./ucan/index.js"
 
 
@@ -28,8 +28,8 @@ export type Permissions = {
 }
 
 export type FileSystemPermissions = {
-  private?: Array<DistinctivePath>
-  public?: Array<DistinctivePath>
+  private?: Array<Distinctive<Path.Segments>>
+  public?: Array<Distinctive<Path.Segments>>
 }
 
 export type PlatformPermissions = {
@@ -61,19 +61,19 @@ export function appId(app: AppInfo): string {
  * Lists the filesystems paths for a set of `Permissions`.
  * This'll return a list of `DistinctivePath`s.
  */
-export function permissionPaths(permissions: Permissions): DistinctivePath[] {
-  let list = [] as DistinctivePath[]
+export function permissionPaths(permissions: Permissions): Distinctive<Path.Branched>[] {
+  let list = [] as Distinctive<Path.Branched>[]
 
   if (permissions.app) list.push(Path.appData(permissions.app))
   if (permissions.fs?.private) list = list.concat(
-    permissions.fs?.private.map(p => Path.combine(
-      Path.directory(Path.Branch.Private),
+    permissions.fs?.private.map(p => Path.withBranch(
+      Path.Branch.Private,
       p
     ))
   )
   if (permissions.fs?.public) list = list.concat(
-    permissions.fs?.public.map(p => Path.combine(
-      Path.directory(Path.Branch.Public),
+    permissions.fs?.public.map(p => Path.withBranch(
+      Path.Branch.Public,
       p
     ))
   )

--- a/src/repositories/ucans.ts
+++ b/src/repositories/ucans.ts
@@ -46,14 +46,14 @@ export class Repo extends Repository<Ucan.Ucan> {
    * Look up a UCAN with a file system path.
    */
   async lookupFilesystemUcan(
-    path: DistinctivePath | "*"
+    path: DistinctivePath<Path.Segments> | "*"
   ): Promise<Ucan.Ucan | null> {
     const god = this.getByKey("*")
     if (god) return god
 
     const all = path === "*"
-    const isDirectory = all ? false : Path.isDirectory(path as DistinctivePath)
-    const pathParts = all ? [ "*" ] : Path.unwrap(path as DistinctivePath)
+    const isDirectory = all ? false : Path.isDirectory(path)
+    const pathParts = all ? [ "*" ] : Path.unwrap(path)
 
     const prefix = filesystemPrefix()
 

--- a/tests/fs/concurrency.node.test.ts
+++ b/tests/fs/concurrency.node.test.ts
@@ -10,9 +10,9 @@ describe("the filesystem", () => {
   it("performs actions concurrently", async function () {
     const fs = await emptyFilesystem()
 
-    const pathA = Path.file(Path.Branch.Private, "a")
-    const pathB = Path.file(Path.Branch.Private, "b")
-    const pathC = Path.file(Path.Branch.Private, "c", "foo")
+    const pathA = Path.file("private", "a")
+    const pathB = Path.file("private", "b")
+    const pathC = Path.file("private", "c", "foo")
 
     await Promise.all([
       fs.write(pathA, from_s("x"))

--- a/tests/fs/data.node.test.ts
+++ b/tests/fs/data.node.test.ts
@@ -14,7 +14,7 @@ describe("the filesystem", () => {
 
     expect(
       await fs.exists(
-        Path.file(Path.Branch.Private, "Welcome.txt")
+        Path.file("private", "Welcome.txt")
       )
     ).toBe(true)
   })

--- a/tests/fs/integration.node.test.ts
+++ b/tests/fs/integration.node.test.ts
@@ -3,9 +3,9 @@ import expect from "expect"
 
 import { loadCARWithRoot } from "../helpers/loadCAR.js"
 
-import FileSystem from "../../src/fs/filesystem.js"
+import * as Path from "../../src/path/index.js"
 import { File } from "../../src/fs/types.js"
-import * as path from "../../src/path/index.js"
+import FileSystem from "../../src/fs/filesystem.js"
 
 import { loadFilesystem } from "../helpers/filesystem.js"
 import { isSoftLink } from "../../src/fs/types/check.js"
@@ -18,22 +18,22 @@ describe("the filesystem", () => {
     const readKey = Uint8arrays.fromString("pJW/xgBGck9/ZXwQHNPhV3zSuqGlUpXiChxwigwvUws=", "base64pad")
     const fs = await loadFilesystem(rootCID, readKey)
 
-    let files = await listFiles(fs, path.directory("public"))
-    files = files.concat(await listFiles(fs, path.directory("private")))
+    let files = await listFiles(fs, Path.directory("private"))
+    files = files.concat(await listFiles(fs, Path.directory("private")))
 
     expect(files).not.toEqual([])
   })
 })
 
-async function listFiles(fs: FileSystem, searchPath: path.DirectoryPath): Promise<File[]> {
+async function listFiles(fs: FileSystem, searchPath: Path.Directory<Path.Partitioned<Path.Partition>>): Promise<File[]> {
   let files: File[] = []
   for (const [ subName, sub ] of Object.entries(await fs.ls(searchPath))) {
     if (isSoftLink(sub)) continue
     if (sub.isFile) {
-      const file = await fs.get(path.combine(searchPath, path.file(subName))) as File
+      const file = await fs.get(Path.combine(searchPath, Path.file(subName))) as File
       files.push(file)
     } else {
-      const subFiles = await listFiles(fs, path.combine(searchPath, path.directory(subName)) as path.DirectoryPath)
+      const subFiles = await listFiles(fs, Path.combine(searchPath, Path.directory(subName)))
       files = files.concat(subFiles)
     }
   }

--- a/tests/fs/share.node.test.ts
+++ b/tests/fs/share.node.test.ts
@@ -8,7 +8,6 @@ import * as Path from "../../src/path/index.js"
 import * as Protocol from "../../src/fs/protocol/index.js"
 import * as SharingKey from "../../src/fs/protocol/shared/key.js"
 
-import { Branch } from "../../src/path/index.js"
 import { SymmAlg } from "../../src/components/crypto/implementation.js"
 import { components } from "../helpers/components.js"
 import { decodeCID } from "../../src/common/index.js"
@@ -33,8 +32,8 @@ describe("the filesystem", () => {
     const C = Uint8arrays.fromString("🕵️‍♀️", "utf8")
     const F = Uint8arrays.fromString("🍻", "utf8")
 
-    await fs.write(Path.file(Branch.Private, "a", "b", "c.txt"), C)
-    await fs.write(Path.file(Branch.Private, "a", "d", "e", "f.txt"), F)
+    await fs.write(Path.file("private", "a", "b", "c.txt"), C)
+    await fs.write(Path.file("private", "a", "d", "e", "f.txt"), F)
 
     // Test identifiers
     const exchangeKeyPair = await components.crypto.rsa.genKey()
@@ -47,16 +46,16 @@ describe("the filesystem", () => {
     const senderDID = DID.publicKeyToDid(components.crypto, senderPubKey, "rsa")
 
     // Create the `/shared` entries
-    const itemC = await fs.get(Path.file(Branch.Private, "a", "b", "c.txt"))
-    const itemE = await fs.get(Path.directory(Branch.Private, "a", "d", "e"))
+    const itemC = await fs.get(Path.file("private", "a", "b", "c.txt"))
+    const itemE = await fs.get(Path.directory("private", "a", "d", "e"))
 
     if (!PrivateFile.instanceOf(itemC)) throw new Error("Not a PrivateFile")
     if (!PrivateTree.instanceOf(itemE)) throw new Error("Not a PrivateTree")
 
     await fs.sharePrivate(
       [
-        Path.file(Branch.Private, "a", "b", "c.txt"),
-        Path.directory(Branch.Private, "a", "d", "e")
+        Path.file("private", "a", "b", "c.txt"),
+        Path.directory("private", "a", "d", "e")
       ],
       {
         sharedBy: { rootDid: senderDID, username: "anonymous" },

--- a/tests/fs/tree.node.test.ts
+++ b/tests/fs/tree.node.test.ts
@@ -11,8 +11,8 @@ describe("the filesystem", () => {
     const fs = await emptyFilesystem()
     const expected = Uint8arrays.fromString("content", "utf8")
 
-    const privatePath = Path.file(Path.Branch.Private, "a", "b", "c.txt")
-    const publicPath = Path.file(Path.Branch.Public, "a", "b", "c.txt")
+    const privatePath = Path.file("private", "a", "b", "c.txt")
+    const publicPath = Path.file("public", "a", "b", "c.txt")
 
     await fs.write(privatePath, expected)
     await fs.write(publicPath, expected)

--- a/tests/helpers/filesystem.ts
+++ b/tests/helpers/filesystem.ts
@@ -29,7 +29,7 @@ export async function loadFilesystem(cid: CID, readKey?: Uint8Array): Promise<Fi
       await Identifiers.readKey({
         accountDID: account.rootDID,
         crypto,
-        path: Path.directory(Path.Branch.Private)
+        path: Path.directory("private")
       })
     )
   }


### PR DESCRIPTION
This restricts the paths that can be used with the file system POSIX interface. For example, `fs.write` now requires a file path that starts with `"private"` or `"public"` and must have at least one more path segment.

```ts
fs.write(
  path.file("private", "fileName")
)
```

The other neat thing about this is when you start writing the following in your editor with the Typescript LSP:
```ts
await fs.write(
  Path.file("")
)
```
It'll suggest `"private"` or `"public"` so people don't have to guess anymore what to type in there as the first item.

## Further notes

- `Branch` has been renamed to `RootBranch`
- Introduces the concept of `Partition`s which are `RootBranch`es that can be used the POSIX file system interface.
- You can also use the `RootBranch` enum to provide string values, for the people that prefer to use a constant.
- I might have unnecessarily restricted some functions, let me know if you find any.
- My only worry about this is that people won't be able to write these types themselves. That said, I don't think anyone will need to.

Thoughts?

## How to write these types by hand

```ts
import { Partitioned, PartitionedNonEmpty, Segments, SegmentsNonEmpty } from "webnative/path/index"
import { Partition, Private, Public } from "webnative/path/index"
import { DirectoryPath, FilePath } from "webnative/path/index"

// Regular old path, no restrictions
path.file() as FilePath<Segments> // { file: [] }

// Must have at least one segment
path.file("segment") as FilePath<SegmentsNonEmpty>

// Must use a WNFS partition, can be public or private partition
path.directory("public") as DirectoryPath<Partitioned<Partition>>>

// Must use the private partition
path.directory("private") as DirectoryPath<Partitioned<Private>>>

// Must use the private partition and have at least one segment besides the partition
path.directory("private", "dir") as DirectoryPath<PartitionedNonEmpty<Private>>>
```

## Closes

Closes #457 