### PR TITLE
remove program.session property

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -143,7 +143,6 @@ export type Program = ShortHands & {
   }
   configuration: Configuration
   components: Components
-  session: Maybe<Session>
 }
 
 
@@ -579,14 +578,12 @@ export async function assemble(config: Configuration, components: Components): P
     }
   }
 
-  // Fin
   return {
     ...shorthands,
     configuration: { ...config },
     auth,
     components,
-    capabilities,
-    session,
+    capabilities
   }
 }
 


### PR DESCRIPTION
Remove the property `program.session` from the program object, because it was confusing having multiple ways to access the same `session` object. 

After this PR, there is one way to access the session:
```js
session.value = await program.auth.session()
```

This eliminates the potential confusion around requesting capabilities vs using an authentication strategy — https://github.com/snail-situation/hermes/discussions/42

------

[see chat log](https://discord.com/channels/478735028319158273/678353918752718848/1066454227435659355)

------

The tests still pass after I removed the `program.session` property.

----

Is there something I have overlooked or am not aware of? Would this break any potential use cases I am not considering?

