### PR TITLE
Add event emitter interface and two file system events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 #### Additions
 
+- Adds an event emitter interface so you can listen to various events. This release comes with two events: `fileSystem.local-change` for listening to file system changes and `fileSystem.published` to listen for successful publishes.
 - Adds `program.fileSystem.recover({ newUsername, oldUsername, readKey })` shorthand method so apps will no longer have to implement the FS recovery flow manually.
 - Adds `program.accountDID(username)` shorthand method to retrieve the root DID of a given account username.
 - Adds the file system data functions as shorthand methods.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "blockstore-datastore-adapter": "^4.0.0",
         "datastore-core": "^8.0.2",
         "datastore-level": "^9.0.4",
-        "emittery": "^1.0.1",
         "events": "^3.3.0",
         "fission-bloom-filters": "1.7.1",
         "ipfs-core-types": "0.13.0",
@@ -54,7 +53,7 @@
         "rimraf": "^3.0.2",
         "ts-node": "^10.9.1",
         "tslib": "^2.4.1",
-        "typedoc": "^0.23.21",
+        "typedoc": "^0.23.24",
         "typedoc-plugin-missing-exports": "^1.0.0",
         "typescript": "^4.8.4",
         "util": "^0.12.4"
@@ -3806,17 +3805,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/emittery": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/emittery/-/emittery-1.0.1.tgz",
-      "integrity": "sha512-2ID6FdrMD9KDLldGesP6317G78K7km/kMcwItRtVFva7I/cSEOIaLpewaUb+YLXVwdAp3Ctfxh/V5zIl1sj7dQ==",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
       }
     },
     "node_modules/emoji-regex": {
@@ -7660,9 +7648,9 @@
       "dev": true
     },
     "node_modules/marked": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.1.tgz",
-      "integrity": "sha512-VK1/jNtwqDLvPktNpL0Fdg3qoeUZhmRsuiIjPEy/lHwXW4ouLoZfO4XoWd4ClDt+hupV1VLpkZhEovjU0W/kqA==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.12.tgz",
+      "integrity": "sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw==",
       "dev": true,
       "bin": {
         "marked": "bin/marked.js"
@@ -9360,14 +9348,14 @@
       }
     },
     "node_modules/shiki": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.11.1.tgz",
-      "integrity": "sha512-EugY9VASFuDqOexOgXR18ZV+TbFrQHeCpEYaXamO+SZlsnT/2LxuLBX25GGtIrwaEVFXUAbUQ601SWE2rMwWHA==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.12.1.tgz",
+      "integrity": "sha512-aieaV1m349rZINEBkjxh2QbBvFFQOlgqYTNtCal82hHj4dDZ76oMlQIX+C7ryerBTDiga3e5NfH6smjdJ02BbQ==",
       "dev": true,
       "dependencies": {
-        "jsonc-parser": "^3.0.0",
-        "vscode-oniguruma": "^1.6.1",
-        "vscode-textmate": "^6.0.0"
+        "jsonc-parser": "^3.2.0",
+        "vscode-oniguruma": "^1.7.0",
+        "vscode-textmate": "^8.0.0"
       }
     },
     "node_modules/side-channel": {
@@ -9927,15 +9915,15 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.23.21",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.21.tgz",
-      "integrity": "sha512-VNE9Jv7BgclvyH9moi2mluneSviD43dCE9pY8RWkO88/DrEgJZk9KpUk7WO468c9WWs/+aG6dOnoH7ccjnErhg==",
+      "version": "0.23.24",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.24.tgz",
+      "integrity": "sha512-bfmy8lNQh+WrPYcJbtjQ6JEEsVl/ce1ZIXyXhyW+a1vFrjO39t6J8sL/d6FfAGrJTc7McCXgk9AanYBSNvLdIA==",
       "dev": true,
       "dependencies": {
         "lunr": "^2.3.9",
-        "marked": "^4.0.19",
-        "minimatch": "^5.1.0",
-        "shiki": "^0.11.1"
+        "marked": "^4.2.5",
+        "minimatch": "^5.1.2",
+        "shiki": "^0.12.1"
       },
       "bin": {
         "typedoc": "bin/typedoc"
@@ -9966,9 +9954,9 @@
       }
     },
     "node_modules/typedoc/node_modules/minimatch": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
-      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -10172,15 +10160,15 @@
       "dev": true
     },
     "node_modules/vscode-oniguruma": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
-      "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
       "dev": true
     },
     "node_modules/vscode-textmate": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-6.0.0.tgz",
-      "integrity": "sha512-gu73tuZfJgu+mvCSy4UZwd2JXykjK9zAZsfmDeut5dx/1a7FeTk0XwJsSuqQn+cuMCGVbIBfl+s53X4T19DnzQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
       "dev": true
     },
     "node_modules/walkdir": {
@@ -13370,11 +13358,6 @@
         "encoding": "^0.1.13"
       }
     },
-    "emittery": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/emittery/-/emittery-1.0.1.tgz",
-      "integrity": "sha512-2ID6FdrMD9KDLldGesP6317G78K7km/kMcwItRtVFva7I/cSEOIaLpewaUb+YLXVwdAp3Ctfxh/V5zIl1sj7dQ=="
-    },
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -16211,9 +16194,9 @@
       "dev": true
     },
     "marked": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.1.tgz",
-      "integrity": "sha512-VK1/jNtwqDLvPktNpL0Fdg3qoeUZhmRsuiIjPEy/lHwXW4ouLoZfO4XoWd4ClDt+hupV1VLpkZhEovjU0W/kqA==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.12.tgz",
+      "integrity": "sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw==",
       "dev": true
     },
     "merge-options": {
@@ -17423,14 +17406,14 @@
       "dev": true
     },
     "shiki": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.11.1.tgz",
-      "integrity": "sha512-EugY9VASFuDqOexOgXR18ZV+TbFrQHeCpEYaXamO+SZlsnT/2LxuLBX25GGtIrwaEVFXUAbUQ601SWE2rMwWHA==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.12.1.tgz",
+      "integrity": "sha512-aieaV1m349rZINEBkjxh2QbBvFFQOlgqYTNtCal82hHj4dDZ76oMlQIX+C7ryerBTDiga3e5NfH6smjdJ02BbQ==",
       "dev": true,
       "requires": {
-        "jsonc-parser": "^3.0.0",
-        "vscode-oniguruma": "^1.6.1",
-        "vscode-textmate": "^6.0.0"
+        "jsonc-parser": "^3.2.0",
+        "vscode-oniguruma": "^1.7.0",
+        "vscode-textmate": "^8.0.0"
       }
     },
     "side-channel": {
@@ -17865,15 +17848,15 @@
       "dev": true
     },
     "typedoc": {
-      "version": "0.23.21",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.21.tgz",
-      "integrity": "sha512-VNE9Jv7BgclvyH9moi2mluneSviD43dCE9pY8RWkO88/DrEgJZk9KpUk7WO468c9WWs/+aG6dOnoH7ccjnErhg==",
+      "version": "0.23.24",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.24.tgz",
+      "integrity": "sha512-bfmy8lNQh+WrPYcJbtjQ6JEEsVl/ce1ZIXyXhyW+a1vFrjO39t6J8sL/d6FfAGrJTc7McCXgk9AanYBSNvLdIA==",
       "dev": true,
       "requires": {
         "lunr": "^2.3.9",
-        "marked": "^4.0.19",
-        "minimatch": "^5.1.0",
-        "shiki": "^0.11.1"
+        "marked": "^4.2.5",
+        "minimatch": "^5.1.2",
+        "shiki": "^0.12.1"
       },
       "dependencies": {
         "brace-expansion": {
@@ -17886,9 +17869,9 @@
           }
         },
         "minimatch": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
-          "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+          "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
           "dev": true,
           "requires": {
             "brace-expansion": "^2.0.1"
@@ -18067,15 +18050,15 @@
       }
     },
     "vscode-oniguruma": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
-      "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
       "dev": true
     },
     "vscode-textmate": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-6.0.0.tgz",
-      "integrity": "sha512-gu73tuZfJgu+mvCSy4UZwd2JXykjK9zAZsfmDeut5dx/1a7FeTk0XwJsSuqQn+cuMCGVbIBfl+s53X4T19DnzQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
       "dev": true
     },
     "walkdir": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "blockstore-datastore-adapter": "^4.0.0",
         "datastore-core": "^8.0.2",
         "datastore-level": "^9.0.4",
+        "emittery": "^1.0.1",
         "events": "^3.3.0",
         "fission-bloom-filters": "1.7.1",
         "ipfs-core-types": "0.13.0",
@@ -3805,6 +3806,17 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/emittery": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-1.0.1.tgz",
+      "integrity": "sha512-2ID6FdrMD9KDLldGesP6317G78K7km/kMcwItRtVFva7I/cSEOIaLpewaUb+YLXVwdAp3Ctfxh/V5zIl1sj7dQ==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
       }
     },
     "node_modules/emoji-regex": {
@@ -13357,6 +13369,11 @@
       "requires": {
         "encoding": "^0.1.13"
       }
+    },
+    "emittery": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-1.0.1.tgz",
+      "integrity": "sha512-2ID6FdrMD9KDLldGesP6317G78K7km/kMcwItRtVFva7I/cSEOIaLpewaUb+YLXVwdAp3Ctfxh/V5zIl1sj7dQ=="
     },
     "emoji-regex": {
       "version": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "blockstore-datastore-adapter": "^4.0.0",
     "datastore-core": "^8.0.2",
     "datastore-level": "^9.0.4",
+    "emittery": "^1.0.1",
     "events": "^3.3.0",
     "fission-bloom-filters": "1.7.1",
     "ipfs-core-types": "0.13.0",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
     "blockstore-datastore-adapter": "^4.0.0",
     "datastore-core": "^8.0.2",
     "datastore-level": "^9.0.4",
-    "emittery": "^1.0.1",
     "events": "^3.3.0",
     "fission-bloom-filters": "1.7.1",
     "ipfs-core-types": "0.13.0",
@@ -127,7 +126,7 @@
     "rimraf": "^3.0.2",
     "ts-node": "^10.9.1",
     "tslib": "^2.4.1",
-    "typedoc": "^0.23.21",
+    "typedoc": "^0.23.24",
     "typedoc-plugin-missing-exports": "^1.0.0",
     "typescript": "^4.8.4",
     "util": "^0.12.4"

--- a/src/common/event-emitter.ts
+++ b/src/common/event-emitter.ts
@@ -3,17 +3,17 @@ export type EventListener<E> = (event: E) => void
 export class EventEmitter<EventMap> {
   private readonly events: Map<keyof EventMap, Set<EventListener<unknown>>> = new Map()
 
-  public on<K extends keyof EventMap>(eventName: K, listener: EventListener<EventMap[K]>): void {
+  public on<K extends keyof EventMap>(eventName: K, listener: EventListener<EventMap[ K ]>): void {
     const eventSet = this.events.get(eventName)
 
     if (eventSet === undefined) {
-      this.events.set(eventName, new Set([listener]) as Set<EventListener<unknown>>)
+      this.events.set(eventName, new Set([ listener ]) as Set<EventListener<unknown>>)
     } else {
       eventSet.add(listener as EventListener<unknown>)
     }
   }
 
-  public removeListener<K extends keyof EventMap>(eventName: K, listener: EventListener<EventMap[K]>): void {
+  public off<K extends keyof EventMap>(eventName: K, listener: EventListener<EventMap[ K ]>): void {
     const eventSet = this.events.get(eventName)
     if (eventSet === undefined) return
 
@@ -24,9 +24,9 @@ export class EventEmitter<EventMap> {
     }
   }
 
-  public emit<K extends keyof EventMap>(eventName: K, event: EventMap[K]): void {
-    this.events.get(eventName)?.forEach((listener: EventListener<EventMap[K]>) => {
-      listener.apply(this, [event])
+  public emit<K extends keyof EventMap>(eventName: K, event: EventMap[ K ]): void {
+    this.events.get(eventName)?.forEach((listener: EventListener<EventMap[ K ]>) => {
+      listener.apply(this, [ event ])
     })
   }
 }

--- a/src/common/event-emitter.ts
+++ b/src/common/event-emitter.ts
@@ -1,21 +1,6 @@
 export type EventListener<E> = (event: E) => void
 
-/**
- * Events interface.
- *
- * Subscribe to events using `on` and unsubscribe using `off`,
- * alternatively you can use `addListener` and `removeListener`.
- *
- * ```ts
- * program.events.fileSystem.on("local-change", ({ path, root }) => {
- *   console.log("The file system has changed locally 🔔")
- *   console.log("Changed path:", path)
- *   console.log("New data root CID:", root)
- * })
- *
- * program.events.fileSystem.off("published")
- * ```
- */
+
 export class EventEmitter<EventMap> {
   private readonly events: Map<keyof EventMap, Set<EventListener<unknown>>> = new Map()
 

--- a/src/common/event-emitter.ts
+++ b/src/common/event-emitter.ts
@@ -3,7 +3,8 @@ export type EventListener<E> = (event: E) => void
 /**
  * Events interface.
  *
- * Subscribe to events using `on` and unsubscribe using `off`.
+ * Subscribe to events using `on` and unsubscribe using `off`,
+ * alternatively you can use `addListener` and `removeListener`.
  *
  * ```ts
  * program.events.fileSystem.on("local-change", ({ path, root }) => {
@@ -18,7 +19,7 @@ export type EventListener<E> = (event: E) => void
 export class EventEmitter<EventMap> {
   private readonly events: Map<keyof EventMap, Set<EventListener<unknown>>> = new Map()
 
-  public on<K extends keyof EventMap>(eventName: K, listener: EventListener<EventMap[ K ]>): void {
+  public addListener<K extends keyof EventMap>(eventName: K, listener: EventListener<EventMap[ K ]>): void {
     const eventSet = this.events.get(eventName)
 
     if (eventSet === undefined) {
@@ -28,7 +29,7 @@ export class EventEmitter<EventMap> {
     }
   }
 
-  public off<K extends keyof EventMap>(eventName: K, listener: EventListener<EventMap[ K ]>): void {
+  public removeListener<K extends keyof EventMap>(eventName: K, listener: EventListener<EventMap[ K ]>): void {
     const eventSet = this.events.get(eventName)
     if (eventSet === undefined) return
 
@@ -38,6 +39,9 @@ export class EventEmitter<EventMap> {
       this.events.delete(eventName)
     }
   }
+
+  on = this.addListener
+  off = this.removeListener
 
   public emit<K extends keyof EventMap>(eventName: K, event: EventMap[ K ]): void {
     this.events.get(eventName)?.forEach((listener: EventListener<EventMap[ K ]>) => {

--- a/src/common/event-emitter.ts
+++ b/src/common/event-emitter.ts
@@ -1,5 +1,20 @@
 export type EventListener<E> = (event: E) => void
 
+/**
+ * Events interface.
+ *
+ * Subscribe to events using `on` and unsubscribe using `off`.
+ *
+ * ```ts
+ * program.events.fileSystem.on("local-change", ({ path, root }) => {
+ *   console.log("The file system has changed locally 🔔")
+ *   console.log("Changed path:", path)
+ *   console.log("New data root CID:", root)
+ * })
+ *
+ * program.events.fileSystem.off("published")
+ * ```
+ */
 export class EventEmitter<EventMap> {
   private readonly events: Map<keyof EventMap, Set<EventListener<unknown>>> = new Map()
 

--- a/src/components/auth/implementation.ts
+++ b/src/components/auth/implementation.ts
@@ -1,6 +1,7 @@
 import type { Channel, ChannelOptions } from "./channel.js"
 
 import { Configuration } from "../../configuration.js"
+import { EventEmitter } from "../../events.js"
 import { Maybe } from "../../common/types.js"
 import { Session } from "../../session.js"
 
@@ -9,7 +10,7 @@ export type Implementation<C> = {
   type: string
 
   // `Session` producer
-  session: (components: C, authenticatedUsername: Maybe<string>, config: Configuration) => Promise<Maybe<Session>>
+  session: (components: C, authenticatedUsername: Maybe<string>, config: Configuration, eventEmitter: EventEmitter) => Promise<Maybe<Session>>
 
   // Account creation
   isUsernameAvailable: (username: string) => Promise<boolean>

--- a/src/components/auth/implementation.ts
+++ b/src/components/auth/implementation.ts
@@ -1,7 +1,7 @@
 import type { Channel, ChannelOptions } from "./channel.js"
 
+import * as Events from "../../events.js"
 import { Configuration } from "../../configuration.js"
-import { EventEmitter } from "../../events.js"
 import { Maybe } from "../../common/types.js"
 import { Session } from "../../session.js"
 
@@ -10,7 +10,7 @@ export type Implementation<C> = {
   type: string
 
   // `Session` producer
-  session: (components: C, authenticatedUsername: Maybe<string>, config: Configuration, eventEmitter: EventEmitter) => Promise<Maybe<Session>>
+  session: (components: C, authenticatedUsername: Maybe<string>, config: Configuration, eventEmitters: { fileSystem: Events.Emitter<Events.FileSystem> }) => Promise<Maybe<Session>>
 
   // Account creation
   isUsernameAvailable: (username: string) => Promise<boolean>

--- a/src/components/auth/implementation/wnfs.ts
+++ b/src/components/auth/implementation/wnfs.ts
@@ -12,6 +12,7 @@ import * as TypeChecks from "../../../common/type-checks.js"
 import * as Ucan from "../../../ucan/index.js"
 
 import { Configuration } from "../../../configuration.js"
+import { EventEmitter } from "../../../events.js"
 import { LinkingError } from "../../../linking/common.js"
 import { Maybe } from "../../../common/types.js"
 import { Session } from "../../../session.js"
@@ -87,7 +88,8 @@ export async function linkDevice(
 export async function session(
   components: Components,
   authedUsername: Maybe<string>,
-  config: Configuration
+  config: Configuration,
+  eventEmitter: EventEmitter
 ): Promise<Maybe<Session>> {
   if (authedUsername) {
     // Self-authorize a filesystem UCAN if needed
@@ -126,6 +128,8 @@ export async function session(
       undefined :
       await loadFileSystem({
         config,
+        eventEmitter,
+
         dependencies: {
           crypto: components.crypto,
           depot: components.depot,

--- a/src/components/auth/implementation/wnfs.ts
+++ b/src/components/auth/implementation/wnfs.ts
@@ -6,13 +6,13 @@ import type { Implementation } from "../implementation.js"
 
 import * as Base from "./base.js"
 import * as DID from "../../../did/index.js"
+import * as Events from "../../../events.js"
 import * as RootKey from "../../../common/root-key.js"
 import * as SessionMod from "../../../session.js"
 import * as TypeChecks from "../../../common/type-checks.js"
 import * as Ucan from "../../../ucan/index.js"
 
 import { Configuration } from "../../../configuration.js"
-import { EventEmitter } from "../../../events.js"
 import { LinkingError } from "../../../linking/common.js"
 import { Maybe } from "../../../common/types.js"
 import { Session } from "../../../session.js"
@@ -89,7 +89,7 @@ export async function session(
   components: Components,
   authedUsername: Maybe<string>,
   config: Configuration,
-  eventEmitter: EventEmitter
+  eventEmitters: { fileSystem: Events.Emitter<Events.FileSystem> }
 ): Promise<Maybe<Session>> {
   if (authedUsername) {
     // Self-authorize a filesystem UCAN if needed
@@ -128,7 +128,6 @@ export async function session(
       undefined :
       await loadFileSystem({
         config,
-        eventEmitter,
 
         dependencies: {
           crypto: components.crypto,
@@ -137,6 +136,7 @@ export async function session(
           reference: components.reference,
           storage: components.storage,
         },
+        eventEmitter: eventEmitters.fileSystem,
         username: authedUsername,
       })
 

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,0 +1,27 @@
+import Emittery from "emittery"
+import { CID } from "./common/cid.js"
+import { DistinctivePath } from "./path/index.js"
+
+
+export type Events = {
+  "fileSystem:local-change": { root: CID, path: DistinctivePath }
+  "fileSystem:published": { root: CID }
+}
+
+
+/**
+ * Events interface.
+ *
+ * Subscribe to events using `on` or `once` (multiple events are allowed),
+ * and unsubscribe using `off`.
+ *
+ * More info on the [emittery Github readme](https://github.com/sindresorhus/emittery/tree/f0b3c2bf8dc985a7dde0e39607e30950394be54b#usage).
+ */
+export type EventEmitter = Emittery<Events>
+
+
+export function createEmitter(): EventEmitter {
+  return new Emittery({
+    debug: { name: "Webnative" }
+  })
+}

--- a/src/events.ts
+++ b/src/events.ts
@@ -15,6 +15,16 @@ export type Events = {
  * Subscribe to events using `on` or `once` (multiple events are allowed),
  * and unsubscribe using `off`.
  *
+ * ```ts
+ * program.events.on("fileSystem:local-change", ({ path, root }) => {
+ *   console.log("The file system has changed locally 🔔")
+ *   console.log("Changed path:", path)
+ *   console.log("New data root CID:", root)
+ * })
+ *
+ * program.events.off("fileSystem:published")
+ * ```
+ *
  * More info on the [emittery Github readme](https://github.com/sindresorhus/emittery/tree/f0b3c2bf8dc985a7dde0e39607e30950394be54b#usage).
  */
 export type EventEmitter = Emittery<Events>

--- a/src/events.ts
+++ b/src/events.ts
@@ -4,7 +4,7 @@ import { DistinctivePath, Partition, Partitioned } from "./path/index.js"
 
 
 export type Events = {
-  "fileSystem:local-change": { root: CID, path: DistinctivePath<Partitioned<Partition>> }
+  "fileSystem:local-change": { root: CID; path: DistinctivePath<Partitioned<Partition>> }
   "fileSystem:published": { root: CID }
 }
 

--- a/src/events.ts
+++ b/src/events.ts
@@ -6,6 +6,28 @@ import { DistinctivePath, Partition, Partitioned } from "./path/index.js"
 export { EventEmitter, EventEmitter as Emitter }
 
 
+/**
+ * Events interface.
+ *
+ * Subscribe to events using `on` and unsubscribe using `off`,
+ * alternatively you can use `addListener` and `removeListener`.
+ *
+ * ```ts
+ * program.fileSystem.on("local-change", ({ path, root }) => {
+ *   console.log("The file system has changed locally 🔔")
+ *   console.log("Changed path:", path)
+ *   console.log("New data root CID:", root)
+ * })
+ *
+ * program.fileSystem.off("published")
+ * ```
+ */
+export type ListenTo<Events> = Pick<
+  EventEmitter<Events>,
+  "addListener" | "removeListener" | "on" | "off"
+>
+
+
 export type FileSystem = {
   "local-change": { root: CID; path: DistinctivePath<Partitioned<Partition>> }
   "published": { root: CID }
@@ -14,4 +36,10 @@ export type FileSystem = {
 
 export function createEmitter<E>(): EventEmitter<E> {
   return new EventEmitter()
+}
+
+
+export function listenTo<E>(emitter: EventEmitter<E>): ListenTo<E> {
+  const { addListener, removeListener, on, off } = emitter
+  return { addListener, removeListener, on, off }
 }

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,10 +1,10 @@
 import Emittery from "emittery"
 import { CID } from "./common/cid.js"
-import { DistinctivePath } from "./path/index.js"
+import { DistinctivePath, Partition, Partitioned } from "./path/index.js"
 
 
 export type Events = {
-  "fileSystem:local-change": { root: CID, path: DistinctivePath }
+  "fileSystem:local-change": { root: CID, path: DistinctivePath<Partitioned<Partition>> }
   "fileSystem:published": { root: CID }
 }
 

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,37 +1,17 @@
-import Emittery from "emittery"
 import { CID } from "./common/cid.js"
+import { EventEmitter } from "./common/event-emitter.js"
 import { DistinctivePath, Partition, Partitioned } from "./path/index.js"
 
 
-export type Events = {
-  "fileSystem:local-change": { root: CID; path: DistinctivePath<Partitioned<Partition>> }
-  "fileSystem:published": { root: CID }
+export { EventEmitter, EventEmitter as Emitter }
+
+
+export type FileSystem = {
+  "local-change": { root: CID; path: DistinctivePath<Partitioned<Partition>> }
+  "published": { root: CID }
 }
 
 
-/**
- * Events interface.
- *
- * Subscribe to events using `on` or `once` (multiple events are allowed),
- * and unsubscribe using `off`.
- *
- * ```ts
- * program.events.on("fileSystem:local-change", ({ path, root }) => {
- *   console.log("The file system has changed locally 🔔")
- *   console.log("Changed path:", path)
- *   console.log("New data root CID:", root)
- * })
- *
- * program.events.off("fileSystem:published")
- * ```
- *
- * More info on the [emittery Github readme](https://github.com/sindresorhus/emittery/tree/f0b3c2bf8dc985a7dde0e39607e30950394be54b#usage).
- */
-export type EventEmitter = Emittery<Events>
-
-
-export function createEmitter(): EventEmitter {
-  return new Emittery({
-    debug: { name: "Webnative" }
-  })
+export function createEmitter<E>(): EventEmitter<E> {
+  return new EventEmitter()
 }

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -27,7 +27,7 @@ import FileSystem from "./fs/filesystem.js"
 export async function loadFileSystem({ config, dependencies, eventEmitter, rootKey, username }: {
   config: Configuration
   dependencies: Dependencies
-  eventEmitter: EventEmitter,
+  eventEmitter: EventEmitter
   rootKey?: Uint8Array
   username: string
 }): Promise<FileSystem> {

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -13,6 +13,7 @@ import * as Versions from "./fs/versions.js"
 import { AuthenticationStrategy } from "./index.js"
 import { RootBranch } from "./path/index.js"
 import { Configuration } from "./configuration.js"
+import { EventEmitter } from "./events.js"
 import { Dependencies } from "./fs/filesystem.js"
 import { Maybe, decodeCID, EMPTY_CID } from "./common/index.js"
 import { type RecoverFileSystemParams } from "./fs/types/params.js"
@@ -23,9 +24,10 @@ import FileSystem from "./fs/filesystem.js"
 /**
  * Load a user's file system.
  */
-export async function loadFileSystem({ config, dependencies, rootKey, username }: {
+export async function loadFileSystem({ config, dependencies, eventEmitter, rootKey, username }: {
   config: Configuration
   dependencies: Dependencies
+  eventEmitter: EventEmitter,
   rootKey?: Uint8Array
   username: string
 }): Promise<FileSystem> {
@@ -88,7 +90,7 @@ export async function loadFileSystem({ config, dependencies, rootKey, username }
     await checkFileSystemVersion(dependencies.depot, config, cid)
     await manners.fileSystem.hooks.beforeLoadExisting(cid, account, dataComponents)
 
-    fs = await FileSystem.fromCID(cid, { account, dependencies, permissions: p })
+    fs = await FileSystem.fromCID(cid, { account, dependencies, eventEmitter, permissions: p })
 
     await manners.fileSystem.hooks.afterLoadExisting(fs, account, dataComponents)
 
@@ -101,6 +103,7 @@ export async function loadFileSystem({ config, dependencies, rootKey, username }
   fs = await FileSystem.empty({
     account,
     dependencies,
+    eventEmitter,
     rootKey,
     permissions: p,
     version: config.fileSystem?.version

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -3,6 +3,7 @@ import { CID } from "multiformats/cid"
 import * as Crypto from "./components/crypto/implementation.js"
 import * as Depot from "./components/depot/implementation.js"
 import * as DID from "./did/index.js"
+import * as Events from "./events.js"
 import * as Protocol from "./fs/protocol/index.js"
 import * as Reference from "./components/reference/implementation.js"
 import * as RootKey from "./common/root-key.js"
@@ -13,7 +14,6 @@ import * as Versions from "./fs/versions.js"
 import { AuthenticationStrategy } from "./index.js"
 import { RootBranch } from "./path/index.js"
 import { Configuration } from "./configuration.js"
-import { EventEmitter } from "./events.js"
 import { Dependencies } from "./fs/filesystem.js"
 import { Maybe, decodeCID, EMPTY_CID } from "./common/index.js"
 import { type RecoverFileSystemParams } from "./fs/types/params.js"
@@ -27,7 +27,7 @@ import FileSystem from "./fs/filesystem.js"
 export async function loadFileSystem({ config, dependencies, eventEmitter, rootKey, username }: {
   config: Configuration
   dependencies: Dependencies
-  eventEmitter: EventEmitter
+  eventEmitter: Events.Emitter<Events.FileSystem>
   rootKey?: Uint8Array
   username: string
 }): Promise<FileSystem> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -182,7 +182,6 @@ export type ShortHands = {
  * - `auth`, a means to control the various auth strategies you configured. Use this to create sessions. Read more about auth components in the toplevel `auth` object documention.
  * - `capabilities`, a means to control capabilities. Use this to collect & request capabilities, and to create a session based on them. Read more about capabilities in the toplevel `capabilities` object documentation.
  * - `components`, your full set of `Components`.
- * - `events`, an object containing various event emitters. Use this to subscribe to, for example, file system events.
  *
  * This object also has a few other functions, for example to load a filesystem.
  * These are called "shorthands" because they're the same functions available

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,24 +144,6 @@ export type Program = ShortHands & {
   }
   configuration: Configuration
   components: Components
-  /**
-   * Events interface.
-   *
-   * Subscribe to events using `on` or `once` (multiple events are allowed),
-   * and unsubscribe using `off`.
-   *
-   * ```ts
-   * program.events.fileSystem.on("local-change", ({ path, root }) => {
-   *   console.log("The file system has changed locally 🔔")
-   *   console.log("Changed path:", path)
-   *   console.log("New data root CID:", root)
-   * })
-   *
-   * program.events.fileSystem.off("published")
-   * ```
-   *
-   * More info on the [emittery Github readme](https://github.com/sindresorhus/emittery/tree/f0b3c2bf8dc985a7dde0e39607e30950394be54b#usage).
-   */
   events: {
     fileSystem: Events.Emitter<Events.FileSystem>
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,25 +144,6 @@ export type Program = ShortHands & {
   }
   configuration: Configuration
   components: Components
-  /**
-   * Events interface.
-   *
-   * Subscribe to events using `on` and unsubscribe using `off`,
-   * alternatively you can use `addListener` and `removeListener`.
-   *
-   * ```ts
-   * program.events.fileSystem.on("local-change", ({ path, root }) => {
-   *   console.log("The file system has changed locally 🔔")
-   *   console.log("Changed path:", path)
-   *   console.log("New data root CID:", root)
-   * })
-   *
-   * program.events.fileSystem.off("published")
-   * ```
-   */
-  events: {
-    fileSystem: Events.Emitter<Events.FileSystem>
-  }
   session: Maybe<Session>
 }
 
@@ -185,7 +166,7 @@ export type ShortHands = {
     hasPublicExchangeKey: (fs: FileSystem) => Promise<boolean>
     load: (username: string) => Promise<FileSystem>
     recover: (params: RecoverFileSystemParams) => Promise<{ success: boolean }>
-  }
+  } & Events.ListenTo<Events.FileSystem>
 }
 
 
@@ -597,17 +578,14 @@ export async function assemble(config: Configuration, components: Components): P
 
     // File system
     fileSystem: {
+      ...Events.listenTo(fsEvents),
+
       addPublicExchangeKey: (fs: FileSystem) => FileSystemData.addPublicExchangeKey(components.crypto, fs),
       addSampleData: (fs: FileSystem) => FileSystemData.addSampleData(fs),
       hasPublicExchangeKey: (fs: FileSystem) => FileSystemData.hasPublicExchangeKey(components.crypto, fs),
       load: (username: string) => loadFileSystem({ config, username, dependencies: components, eventEmitter: fsEvents }),
       recover: (params: RecoverFileSystemParams) => recoverFileSystem({ auth, dependencies: components, ...params }),
     }
-  }
-
-  // Events
-  const events = {
-    fileSystem: fsEvents
   }
 
   // Fin
@@ -617,7 +595,6 @@ export async function assemble(config: Configuration, components: Components): P
     auth,
     components,
     capabilities,
-    events,
     session,
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ import * as Capabilities from "./capabilities.js"
 import * as Crypto from "./components/crypto/implementation.js"
 import * as Depot from "./components/depot/implementation.js"
 import * as DID from "./did/local.js"
+import * as Events from "./events.js"
 import * as FileSystemData from "./fs/data.js"
 import * as IpfsNode from "./components/depot/implementation/ipfs/node.js"
 import * as Manners from "./components/manners/implementation.js"
@@ -50,7 +51,6 @@ import { Components } from "./components.js"
 import { Configuration, namespace } from "./configuration.js"
 import { isString, Maybe } from "./common/index.js"
 import { Session } from "./session.js"
-import { createEmitter, EventEmitter } from "./events.js"
 import { loadFileSystem, recoverFileSystem } from "./filesystem.js"
 import FileSystem from "./fs/filesystem.js"
 
@@ -144,7 +144,27 @@ export type Program = ShortHands & {
   }
   configuration: Configuration
   components: Components
-  events: EventEmitter
+  /**
+   * Events interface.
+   *
+   * Subscribe to events using `on` or `once` (multiple events are allowed),
+   * and unsubscribe using `off`.
+   *
+   * ```ts
+   * program.events.fileSystem.on("local-change", ({ path, root }) => {
+   *   console.log("The file system has changed locally 🔔")
+   *   console.log("Changed path:", path)
+   *   console.log("New data root CID:", root)
+   * })
+   *
+   * program.events.fileSystem.off("published")
+   * ```
+   *
+   * More info on the [emittery Github readme](https://github.com/sindresorhus/emittery/tree/f0b3c2bf8dc985a7dde0e39607e30950394be54b#usage).
+   */
+  events: {
+    fileSystem: Events.Emitter<Events.FileSystem>
+  }
   session: Maybe<Session>
 }
 
@@ -448,7 +468,7 @@ export async function assemble(config: Configuration, components: Components): P
   await ensureBackwardsCompatibility(components, config)
 
   // Event emitter
-  const eventEmitter = createEmitter()
+  const fsEvents = Events.createEmitter<Events.FileSystem>()
 
   // Authenticated user
   const sessionInfo = await SessionMod.restore(components.storage)
@@ -484,7 +504,7 @@ export async function assemble(config: Configuration, components: Components): P
           components,
           newSessionInfo.username,
           config,
-          eventEmitter
+          { fileSystem: fsEvents }
         )
       }
     }
@@ -542,7 +562,7 @@ export async function assemble(config: Configuration, components: Components): P
         await loadFileSystem({
           config,
           dependencies: components,
-          eventEmitter,
+          eventEmitter: fsEvents,
           username,
         })
 
@@ -581,13 +601,15 @@ export async function assemble(config: Configuration, components: Components): P
       addPublicExchangeKey: (fs: FileSystem) => FileSystemData.addPublicExchangeKey(components.crypto, fs),
       addSampleData: (fs: FileSystem) => FileSystemData.addSampleData(fs),
       hasPublicExchangeKey: (fs: FileSystem) => FileSystemData.hasPublicExchangeKey(components.crypto, fs),
-      load: (username: string) => loadFileSystem({ config, eventEmitter, username, dependencies: components }),
+      load: (username: string) => loadFileSystem({ config, username, dependencies: components, eventEmitter: fsEvents }),
       recover: (params: RecoverFileSystemParams) => recoverFileSystem({ auth, dependencies: components, ...params }),
     }
   }
 
   // Events
-  const events = eventEmitter
+  const events = {
+    fileSystem: fsEvents
+  }
 
   // Fin
   return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -185,6 +185,7 @@ export type ShortHands = {
  * - `auth`, a means to control the various auth strategies you configured. Use this to create sessions. Read more about auth components in the toplevel `auth` object documention.
  * - `capabilities`, a means to control capabilities. Use this to collect & request capabilities, and to create a session based on them. Read more about capabilities in the toplevel `capabilities` object documentation.
  * - `components`, your full set of `Components`.
+ * - `events`, an object containing various event emitters. Use this to subscribe to, for example, file system events.
  *
  * This object also has a few other functions, for example to load a filesystem.
  * These are called "shorthands" because they're the same functions available

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,7 +147,8 @@ export type Program = ShortHands & {
   /**
    * Events interface.
    *
-   * Subscribe to events using `on` and unsubscribe using `off`.
+   * Subscribe to events using `on` and unsubscribe using `off`,
+   * alternatively you can use `addListener` and `removeListener`.
    *
    * ```ts
    * program.events.fileSystem.on("local-change", ({ path, root }) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,6 +144,21 @@ export type Program = ShortHands & {
   }
   configuration: Configuration
   components: Components
+  /**
+   * Events interface.
+   *
+   * Subscribe to events using `on` and unsubscribe using `off`.
+   *
+   * ```ts
+   * program.events.fileSystem.on("local-change", ({ path, root }) => {
+   *   console.log("The file system has changed locally 🔔")
+   *   console.log("Changed path:", path)
+   *   console.log("New data root CID:", root)
+   * })
+   *
+   * program.events.fileSystem.off("published")
+   * ```
+   */
   events: {
     fileSystem: Events.Emitter<Events.FileSystem>
   }

--- a/tests/auth/linking.node.test.ts
+++ b/tests/auth/linking.node.test.ts
@@ -41,7 +41,7 @@ describe("account linking", () => {
 
       return {
         send: (data) => channel.emit(`${username}`, data),
-        close: () => channel.off(`${username}`, messageCallback)
+        close: () => channel.removeListener(`${username}`, messageCallback)
       }
     }
 

--- a/tests/auth/linking.node.test.ts
+++ b/tests/auth/linking.node.test.ts
@@ -41,7 +41,7 @@ describe("account linking", () => {
 
       return {
         send: (data) => channel.emit(`${username}`, data),
-        close: () => channel.removeListener(`${username}`, messageCallback)
+        close: () => channel.off(`${username}`, messageCallback)
       }
     }
 

--- a/tests/helpers/filesystem.ts
+++ b/tests/helpers/filesystem.ts
@@ -4,12 +4,16 @@ import * as Identifiers from "../../src/common/identifiers.js"
 import * as Path from "../../src/path/index.js"
 import FileSystem from "../../src/fs/filesystem.js"
 import { account, components, crypto } from "./components.js"
+import { createEmitter } from "../../src/events.js"
 
 
 export function emptyFilesystem(version?: string): Promise<FileSystem> {
+  const eventEmitter = createEmitter()
+
   return FileSystem.empty({
     account,
     dependencies: components,
+    eventEmitter,
     localOnly: true,
     permissions: {
       fs: {
@@ -34,9 +38,11 @@ export async function loadFilesystem(cid: CID, readKey?: Uint8Array): Promise<Fi
     )
   }
 
+  const eventEmitter = createEmitter()
   const fs = await FileSystem.fromCID(cid, {
     account,
     dependencies: components,
+    eventEmitter,
     localOnly: true,
     permissions: {
       fs: {

--- a/tests/helpers/filesystem.ts
+++ b/tests/helpers/filesystem.ts
@@ -1,19 +1,18 @@
 import { CID } from "multiformats/cid"
 
 import * as Identifiers from "../../src/common/identifiers.js"
+import * as Events from "../../src/events.js"
 import * as Path from "../../src/path/index.js"
+
 import FileSystem from "../../src/fs/filesystem.js"
 import { account, components, crypto } from "./components.js"
-import { createEmitter } from "../../src/events.js"
 
 
 export function emptyFilesystem(version?: string): Promise<FileSystem> {
-  const eventEmitter = createEmitter()
-
   return FileSystem.empty({
     account,
     dependencies: components,
-    eventEmitter,
+    eventEmitter: Events.createEmitter<Events.FileSystem>(),
     localOnly: true,
     permissions: {
       fs: {
@@ -38,11 +37,10 @@ export async function loadFilesystem(cid: CID, readKey?: Uint8Array): Promise<Fi
     )
   }
 
-  const eventEmitter = createEmitter()
   const fs = await FileSystem.fromCID(cid, {
     account,
     dependencies: components,
-    eventEmitter,
+    eventEmitter: Events.createEmitter<Events.FileSystem>(),
     localOnly: true,
     permissions: {
       fs: {


### PR DESCRIPTION
__Adds event emitters to the program.__ This allows you to say:

```ts
program.fileSystem.on("local-change", ({ path, root }) => {
  console.log("The file system has changed locally 🔔")
  console.log("Changed path:", path)
  console.log("New data root CID:", root)
})
```

Events added so far
- `fileSystem["local-change"]`
- `fileSystem["published"]`

Events are documented automatically using the types:
<img width="432" alt="Screenshot 2023-01-25 at 18 33 31" src="https://user-images.githubusercontent.com/296665/214638850-158e2362-05c0-4023-b229-02ebf605e685.png">

## Related issues

#136
#413 
#414 

I'm not sure these issues can be closed since they may involve remote changes, which this PR does **not** include. Server changes are needed in order to achieve this. Personally I'd also like to wait for #163 before we go down that road. In any case, this is a good start and people can set up their own notification system using this.