### PR TITLE
Inject debug programs in globalThis context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Adds `program.fileSystem.recover({ newUsername, oldUsername, readKey })` shorthand method so apps will no longer have to implement the FS recovery flow manually.
 - Adds `program.accountDID(username)` shorthand method to retrieve the root DID of a given account username.
 - Adds the file system data functions as shorthand methods.
+- Injects programs into the global namespace when in debug mode. Can be disabled via the configuration.
 
 #### Other
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ const content = new TextDecoder().decode(
 That's it, you have successfully created a Webnative app! 🚀
 
 
-## Basics
+## POSIX Interface
 
 WNFS exposes a familiar POSIX-style interface:
 - `exists`: check if a file or directory exists
@@ -224,3 +224,20 @@ file.history.prior(1606236743)
 ## Migration
 
 Some versions of Webnative require apps to migrate their codebase to address breaking changes. Please see our [migration guide](https://guide.fission.codes/developers/webnative/migration) for help migrating your apps to the latest Webnative version.
+
+
+## Debugging
+
+Debugging mode can be enable by setting `debug` to `true` in your configuration object that you pass to your `Program`. By default this will add your programs to the global context object (eg. `window`) under `globalThis.__webnative.programs` (can be disabled, see API docs).
+
+```ts
+const appInfo = { creator: "Nullsoft", name: "Winamp" }
+
+await wn.program({
+  namespace: appInfo,
+  debug: true
+})
+
+// Automatically exposed Program in debug mode
+const program = globalThis.__webnative[ wn.namespace(appInfo) ] // namespace: "Nullsoft/Winamp"
+```

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -10,11 +10,23 @@ export type Configuration = {
   namespace: string | AppInfo
 
   /**
-   * Enable debug console statements.
+   * Enable debug mode.
    *
    * @default false
    */
   debug?: boolean
+
+  /**
+   * Debugging settings.
+   */
+  debugging?: {
+    /**
+     * Should I add programs to the global context while in debugging mode?
+     *
+     * @default true
+     */
+    injectIntoGlobalContext?: boolean
+  }
 
   /**
    * File system settings.

--- a/src/index.ts
+++ b/src/index.ts
@@ -587,8 +587,8 @@ export async function assemble(config: Configuration, components: Components): P
     }
   }
 
-  // Fin
-  return {
+  // Create `Program`
+  const program = {
     ...shorthands,
     configuration: { ...config },
     auth,
@@ -596,6 +596,23 @@ export async function assemble(config: Configuration, components: Components): P
     capabilities,
     session,
   }
+
+  // Inject into global context if necessary
+  if (config.debug) {
+    const inject = config.debugging?.injectIntoGlobalContext === undefined
+      ? true
+      : config.debugging?.injectIntoGlobalContext
+
+    if (inject) {
+      const container = globalThis as any
+      container.__webnative = container.__webnative || {}
+      container.__webnative.programs = container.__webnative.programs || {}
+      container.__webnative.programs[ namespace(config) ] = program
+    }
+  }
+
+  // Fin
+  return program
 }
 
 


### PR DESCRIPTION
Closes #405 

```ts
wn.program({
  namespace: "example",
  debug: true
})

const program = globalThis.__webnative.programs["example"]
```

Added a section to the [📜 README](https://github.com/fission-codes/webnative/tree/icidasset/debug-inject#debugging) that explains it.