### PR TITLE
Rename 'published' event to 'publish'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 #### Additions
 
-- Adds an event emitter interface so you can listen to various events. This release comes with two events: `fileSystem.local-change` for listening to file system changes and `fileSystem.published` to listen for successful publishes.
+- Adds an event emitter interface so you can listen to various events. This release comes with two events: `fileSystem.local-change` for listening to file system changes and `fileSystem.publish` to listen for successful publishes.
 - Adds `program.fileSystem.recover({ newUsername, oldUsername, readKey })` shorthand method so apps will no longer have to implement the file system recovery flow manually.
 - Adds `program.accountDID(username)` shorthand method to retrieve the root DID of a given account username.
 - Adds the file system data functions as shorthand methods.

--- a/src/events.ts
+++ b/src/events.ts
@@ -19,7 +19,7 @@ export { EventEmitter, EventEmitter as Emitter }
  *   console.log("New data root CID:", root)
  * })
  *
- * program.fileSystem.off("published")
+ * program.fileSystem.off("publish")
  * ```
  */
 export type ListenTo<EventMap> = Pick<
@@ -30,7 +30,7 @@ export type ListenTo<EventMap> = Pick<
 
 export type FileSystem = {
   "local-change": { root: CID; path: DistinctivePath<Partitioned<Partition>> }
-  "published": { root: CID }
+  "publish": { root: CID }
 }
 
 

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -128,7 +128,7 @@ export class FileSystem implements API {
         this._publishing = [ cid, true ]
         return this.dependencies.reference.dataRoot.update(cid, proof).then(() => {
           if (this._publishing && this._publishing[ 0 ] === cid) {
-            eventEmitter.emit("published", { root: cid })
+            eventEmitter.emit("publish", { root: cid })
             this._publishing = false
           }
         })


### PR DESCRIPTION
Use present tense for events.