### PR TITLE
Fixes #486

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### v0.36.1
+
+- Fixes issue with the CID log which in certain scenarios caused Webnative to load the wrong version of an account's file system.
+
 ### v0.36.0
 
 #### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### v0.36.1
 
-Fixes issue with the CID log which in certain scenarios caused Webnative to load the wrong version of an account's file system.
+Fixes an issue with the CID log, which, in certain scenarios, caused Webnative to load the wrong version of an account's file system.
 
 ### v0.36.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### v0.36.1
 
-- Fixes issue with the CID log which in certain scenarios caused Webnative to load the wrong version of an account's file system.
+Fixes issue with the CID log which in certain scenarios caused Webnative to load the wrong version of an account's file system.
 
 ### v0.36.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webnative",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "webnative",
-      "version": "0.36.0",
+      "version": "0.36.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@ipld/dag-cbor": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webnative",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "description": "Webnative SDK",
   "keywords": [
     "WebCrypto",

--- a/src/common/version.ts
+++ b/src/common/version.ts
@@ -1,2 +1,2 @@
-export const VERSION = "0.36.0"
+export const VERSION = "0.36.1"
 export const WASM_WNFS_VERSION = "0.1.7"

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -44,7 +44,7 @@ export async function loadFileSystem({ config, dependencies, eventEmitter, rootK
 
   // Determine the correct CID of the file system to load
   const dataCid = navigator.onLine ? await getDataRoot(reference, username, { maxRetries: 20 }) : null
-  const logIdx = dataCid ? cidLog.length() - cidLog.indexOf(dataCid) - 1 : -1
+  const logIdx = dataCid ? cidLog.indexOf(dataCid) : -1
 
   if (!navigator.onLine) {
     // Offline, use local CID
@@ -59,15 +59,16 @@ export async function loadFileSystem({ config, dependencies, eventEmitter, rootK
     if (cid) manners.log("📓 No DNSLink, using local CID:", cid.toString())
     else manners.log("📓 Creating a new file system")
 
-  } else if (logIdx === 0) {
+  } else if (logIdx === cidLog.length() - 1) {
     // DNS is up to date
     cid = dataCid
     manners.log("📓 DNSLink is up to date:", cid.toString())
 
-  } else if (logIdx > 0) {
+  } else if (logIdx !== -1 && logIdx < cidLog.length() - 1) {
     // DNS is outdated
     cid = cidLog.newest()
-    const idxLog = logIdx === 1 ? "1 newer local entry" : (cidLog.length() - logIdx - 1).toString() + " newer local entries"
+    const diff = cidLog.length() - 1 - logIdx
+    const idxLog = diff === 1 ? "1 newer local entry" : diff.toString() + " newer local entries"
     manners.log("📓 DNSLink is outdated (" + idxLog + "), using local CID:", cid.toString())
 
   } else {

--- a/src/repositories/cid-log.node.test.ts
+++ b/src/repositories/cid-log.node.test.ts
@@ -66,7 +66,7 @@ describe("cid-log", () => {
           const cid = cids[ idx ]
 
           // Get the index of test cid after all CIDs have been added
-          const index = await cidLog.indexOf(cid)
+          const index = cidLog.indexOf(cid)
 
           expect(index).toEqual(idx)
         })
@@ -85,7 +85,7 @@ describe("cid-log", () => {
           const cid = cids[ cids.length - 1 ]
 
           // Get the newest cid after all CIDs have been added
-          const newest = await cidLog.newest()
+          const newest = cidLog.newest()
 
           expect(newest.toString()).toEqual(cid.toString())
         })


### PR DESCRIPTION
Testing the various states:
- **No data cid**: Create new account.
- **Up to date**: Refresh the page after a publish has successfully completed.
- **Outdated**: Refresh the page just after making a change in the file system and just before the publish has finished. That way the DNS becomes out of sync with your local state. Refreshing the page should say "outdated, 1 newer local entry". Repeating this process should increase this counter (ie. 2 newer local entries, and so on).
- **Newer**: Make a change in one session, wait for publish to finish and open app in other session.

Fixes #486 

You can test this with the alpha version: `0.36.1-alpha-1`