### PR TITLE
Fix & re-enable rs-wnfs integration tests

### DIFF
--- a/src/fs/v3/PublicRootWasm.ts
+++ b/src/fs/v3/PublicRootWasm.ts
@@ -13,10 +13,15 @@ import { BaseFile } from "../base/file.js"
 import { Metadata } from "../metadata.js"
 
 
+// This is some global mutable state to work around global mutable state
+// issues with wasm-bindgen. It's important we *never* accidentally initialize the
+// "wnfs" Wasm module twice.
 let initialized = false
 
 async function loadWasm({ manners }: Dependencies) {
-  // MUST NOT initialize twice
+  // MUST be prevented from initializing twice:
+  // https://github.com/fission-codes/webnative/issues/429
+  // https://github.com/rustwasm/wasm-bindgen/issues/3307
   if (initialized) return
   initialized = true
 

--- a/src/fs/v3/PublicRootWasm.ts
+++ b/src/fs/v3/PublicRootWasm.ts
@@ -13,8 +13,13 @@ import { BaseFile } from "../base/file.js"
 import { Metadata } from "../metadata.js"
 
 
+let initialized = false
 
 async function loadWasm({ manners }: Dependencies) {
+  // MUST NOT initialize twice
+  if (initialized) return
+  initialized = true
+
   manners.log(`⏬ Loading WNFS WASM`)
   const before = performance.now()
   // init accepts Promises as arguments

--- a/tests/fs/wasm/public.test.ts
+++ b/tests/fs/wasm/public.test.ts
@@ -9,8 +9,7 @@ import { components } from "../../helpers/components.js"
 
 
 
-// TODO: Fix GC issues
-describe.skip("the wasm public root", () => {
+describe("the wasm public root", () => {
 
   const dependencies = components
 


### PR DESCRIPTION
Fixes #429 

I added the "no changelog" label since this is only a fix for a feature behind an experimental feature flag. I don't think this needs a changelog entry. Right?
