### PR TITLE
Parse DAG-JSON CIDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### V0.36.3
+
+Now parses DAG-JSON formatted CIDs.
+
 ### v0.36.2
 
 Allow symlinks to other file systems to be created.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webnative",
-  "version": "0.36.2",
+  "version": "0.36.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "webnative",
-      "version": "0.36.2",
+      "version": "0.36.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@ipld/dag-cbor": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webnative",
-  "version": "0.36.2",
+  "version": "0.36.3",
   "description": "Webnative SDK",
   "keywords": [
     "WebCrypto",

--- a/src/common/cid.node.test.ts
+++ b/src/common/cid.node.test.ts
@@ -1,0 +1,14 @@
+import expect from "expect"
+import { decodeCID } from "./cid.js"
+
+
+describe("CIDs", () => {
+
+  it("decodes DAG-JSON cids", () => {
+    const CID_STRING = "bafkreicu646jao2xjpkbmk3buom6hmxsexmbwyju22k6wmtnky2ljisv3e"
+    const decoded = decodeCID({ "/": CID_STRING })
+
+    expect(decoded.toString()).toEqual(CID_STRING)
+  })
+
+})

--- a/src/common/cid.node.test.ts
+++ b/src/common/cid.node.test.ts
@@ -6,9 +6,9 @@ describe("CIDs", () => {
 
   it("decodes DAG-JSON cids", () => {
     const CID_STRING = "bafkreicu646jao2xjpkbmk3buom6hmxsexmbwyju22k6wmtnky2ljisv3e"
-    const decoded = decodeCID({ "/": CID_STRING })
+    const cidInstance = decodeCID({ "/": CID_STRING })
 
-    expect(decoded.toString()).toEqual(CID_STRING)
+    expect(cidInstance.toString()).toEqual(CID_STRING)
   })
 
 })

--- a/src/common/cid.ts
+++ b/src/common/cid.ts
@@ -44,7 +44,7 @@ export function decodeCID(val: CID | object | string): CID {
     return CID.create(val.version as Version, val.code, multihash)
   }
 
-  // Legacy issue
+  // Sometimes we can encounter a DAG-JSON encoded CID
   // https://github.com/fission-codes/webnative/issues/459
   // Related to the `ensureSkeletonStringCIDs` function in the `PrivateTree` class
   if (

--- a/src/common/cid.ts
+++ b/src/common/cid.ts
@@ -30,6 +30,7 @@ export function decodeCID(val: CID | object | string): CID {
     return CID.create(val.version, val.code, val.multihash)
   }
 
+  // Older version of the above
   if (
     typeof val === "object" &&
     hasProp(val, "version") &&
@@ -41,6 +42,17 @@ export function decodeCID(val: CID | object | string): CID {
     ))
 
     return CID.create(val.version as Version, val.code, multihash)
+  }
+
+  // Legacy issue
+  // https://github.com/fission-codes/webnative/issues/459
+  // Related to the `ensureSkeletonStringCIDs` function in the `PrivateTree` class
+  if (
+    typeof val === "object" &&
+    hasProp(val, "/") &&
+    typeof val[ "/" ] === "string"
+  ) {
+    return CID.parse(val[ "/" ])
   }
 
   // Unrecognisable CID

--- a/src/common/version.ts
+++ b/src/common/version.ts
@@ -1,2 +1,2 @@
-export const VERSION = "0.36.2"
+export const VERSION = "0.36.3"
 export const WASM_WNFS_VERSION = "0.1.7"


### PR DESCRIPTION
Should fix issues such as #459 where CIDs in the format of `{"/":"CID_STRING"}` (DAG-JSON) are encountered.